### PR TITLE
use IS_TEMPLATE param for template_postgis creation for PG > 9.4

### DIFF
--- a/10-2.5/alpine/initdb-postgis.sh
+++ b/10-2.5/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/10-2.5/initdb-postgis.sh
+++ b/10-2.5/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/10-3.0/alpine/initdb-postgis.sh
+++ b/10-3.0/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/10-3.0/initdb-postgis.sh
+++ b/10-3.0/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/11-2.5/alpine/initdb-postgis.sh
+++ b/11-2.5/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/11-2.5/initdb-postgis.sh
+++ b/11-2.5/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/11-3.0/alpine/initdb-postgis.sh
+++ b/11-3.0/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/11-3.0/initdb-postgis.sh
+++ b/11-3.0/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/12-2.5/alpine/initdb-postgis.sh
+++ b/12-2.5/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/12-2.5/initdb-postgis.sh
+++ b/12-2.5/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/12-3.0/alpine/initdb-postgis.sh
+++ b/12-3.0/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/12-3.0/initdb-postgis.sh
+++ b/12-3.0/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/9.5-2.5/alpine/initdb-postgis.sh
+++ b/9.5-2.5/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/9.5-2.5/initdb-postgis.sh
+++ b/9.5-2.5/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/9.5-3.0/alpine/initdb-postgis.sh
+++ b/9.5-3.0/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/9.5-3.0/initdb-postgis.sh
+++ b/9.5-3.0/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/9.6-2.5/alpine/initdb-postgis.sh
+++ b/9.6-2.5/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/9.6-2.5/initdb-postgis.sh
+++ b/9.6-2.5/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/9.6-3.0/alpine/initdb-postgis.sh
+++ b/9.6-3.0/alpine/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/9.6-3.0/initdb-postgis.sh
+++ b/9.6-3.0/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB

--- a/initdb-postgis.sh
+++ b/initdb-postgis.sh
@@ -7,8 +7,7 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB


### PR DESCRIPTION
From docs
> **istemplate**
>  If true, then this database can be cloned by any user with CREATEDB privileges; if false (the default), then only superusers or the owner of the database can clone it.

I suggest using `IS_TEMPLATE` param where possible to make init-db script simpler and complaint
with postgres security best practices on not editing `pg_database` directly