### PR TITLE
Upgrade to PostGIS v2.5.3 and add PostgreSQL v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,21 @@
 language: bash
 services: docker
 
-dist: trusty
+dist: xenial
 
 env:
-  - VERSION=9.6-2.5
-  - VERSION=9.6-2.5 VARIANT=alpine
-  - VERSION=9.5-2.5
-  - VERSION=9.5-2.5 VARIANT=alpine
   - VERSION=9.4-2.5
   - VERSION=9.4-2.5 VARIANT=alpine
-  - VERSION=11-2.5
-  - VERSION=11-2.5 VARIANT=alpine
+  - VERSION=9.5-2.5
+  - VERSION=9.5-2.5 VARIANT=alpine
+  - VERSION=9.6-2.5
+  - VERSION=9.6-2.5 VARIANT=alpine
   - VERSION=10-2.5
   - VERSION=10-2.5 VARIANT=alpine
+  - VERSION=11-2.5
+  - VERSION=11-2.5 VARIANT=alpine
+  - VERSION=12-2.5
+  - VERSION=12-2.5 VARIANT=alpine
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images
 
 before_script:
-  - env | sort
+  - env | grep -E "VARIANT|VERSION" | sort
   - cd "$VERSION/$VARIANT"
   - image="appropriate/postgis:$VERSION${VARIANT:+-${VARIANT}}"
 

--- a/10-2.5/Dockerfile
+++ b/10-2.5/Dockerfile
@@ -1,15 +1,15 @@
 FROM postgres:10
-MAINTAINER Mike Dillon <mike@appropriate.io>
+
+LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 2.5
-ENV POSTGIS_VERSION 2.5.2+dfsg-1~exp1.pgdg90+1
+ENV POSTGIS_VERSION 2.5.3+dfsg-3.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
-           postgis=$POSTGIS_VERSION \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/10-2.5/README.md
+++ b/10-2.5/README.md
@@ -1,8 +1,8 @@
-# mdillon/postgis
+# postgis/postgis
 
-[![Build Status](https://travis-ci.org/appropriate/docker-postgis.svg)](https://travis-ci.org/appropriate/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/postgis/docker-postgis.svg)](https://travis-ci.org/postgis/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The `mdillon/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, and Postgres 11.
+The `postgis/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides debian and alpine variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, Postgres 11, and Postgres 12.
 
 This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
 
@@ -17,7 +17,7 @@ Unless `-e POSTGRES_DB` is passed to the container at startup time, this databas
 
 In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
 
-    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d mdillon/postgis
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
 
 For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
 

--- a/10-2.5/alpine/Dockerfile
+++ b/10-2.5/alpine/Dockerfile
@@ -1,8 +1,9 @@
 FROM postgres:10-alpine
-MAINTAINER Régis Belson <me@regisbelson.fr>
 
-ENV POSTGIS_VERSION 2.5.2
-ENV POSTGIS_SHA256 225aeaece00a1a6a9af15526af81bef2af27f4c198de820af1367a792ee1d1a9
+LABEL maintainer="PostGIS Project - https://postgis.net"
+
+ENV POSTGIS_VERSION 2.5.3
+ENV POSTGIS_SHA256 402323c83d97f3859bc9083345dd687f933c261efe0830e1262c20c12671f794
 
 RUN set -ex \
     \
@@ -24,19 +25,19 @@ RUN set -ex \
     && apk add --no-cache --virtual .build-deps \
         autoconf \
         automake \
-        g++ \
+        file \
         json-c-dev \
         libtool \
         libxml2-dev \
         make \
         perl \
-    \
-    && apk add --no-cache --virtual .build-deps-edge \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \    
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        clang-dev \
+        g++ \
+        gcc \
         gdal-dev \
         geos-dev \
-        proj4-dev \
+        llvm9-dev \
+        proj-dev \
         protobuf-c-dev \
     && cd /usr/src/postgis \
     && ./autogen.sh \
@@ -48,16 +49,14 @@ RUN set -ex \
     && make install \
     && apk add --no-cache --virtual .postgis-rundeps \
         json-c \
-    && apk add --no-cache --virtual .postgis-rundeps-edge \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \    
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \        
         geos \
         gdal \
-        proj4 \
+        proj \
+        libstdc++ \
         protobuf-c \
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-edge
+    && apk del .fetch-deps .build-deps
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/11-2.5/Dockerfile
+++ b/11-2.5/Dockerfile
@@ -1,15 +1,15 @@
 FROM postgres:11
-MAINTAINER Mike Dillon <mike@appropriate.io>
+
+LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 2.5
-ENV POSTGIS_VERSION 2.5.2+dfsg-1~exp1.pgdg90+1
+ENV POSTGIS_VERSION 2.5.3+dfsg-3.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
-           postgis=$POSTGIS_VERSION \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/11-2.5/README.md
+++ b/11-2.5/README.md
@@ -1,8 +1,8 @@
-# mdillon/postgis
+# postgis/postgis
 
-[![Build Status](https://travis-ci.org/appropriate/docker-postgis.svg)](https://travis-ci.org/appropriate/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/postgis/docker-postgis.svg)](https://travis-ci.org/postgis/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The `mdillon/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, and Postgres 11.
+The `postgis/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides debian and alpine variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, Postgres 11, and Postgres 12.
 
 This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
 
@@ -17,7 +17,7 @@ Unless `-e POSTGRES_DB` is passed to the container at startup time, this databas
 
 In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
 
-    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d mdillon/postgis
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
 
 For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
 

--- a/12-2.5/Dockerfile
+++ b/12-2.5/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:9.4
+FROM postgres:12
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 2.5
-ENV POSTGIS_VERSION 2.5.3+dfsg-3.pgdg90+1
+ENV POSTGIS_VERSION 2.5.3+dfsg-3.pgdg100+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/12-2.5/README.md
+++ b/12-2.5/README.md
@@ -1,0 +1,51 @@
+# mdillon/postgis
+
+[![Build Status](https://travis-ci.org/appropriate/docker-postgis.svg)](https://travis-ci.org/appropriate/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+The `mdillon/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, and Postgres 11.
+
+This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
+
+* `postgis`
+* `postgis_topology`
+* `fuzzystrmatch`
+* `postgis_tiger_geocoder`
+
+Unless `-e POSTGRES_DB` is passed to the container at startup time, this database will be named after the admin user (either `postgres` or the user specified with `-e POSTGRES_USER`). If you would prefer to use the older template database mechanism for enabling PostGIS, the image also provides a PostGIS-enabled template database called `template_postgis`.
+
+## Usage
+
+In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
+
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d mdillon/postgis
+
+For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
+
+Once you have started a database container, you can then connect to the database as follows:
+
+    docker run -it --link some-postgis:postgres --rm postgres \
+        sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
+
+See [the PostGIS documentation](http://postgis.net/docs/postgis_installation.html#create_new_db_extensions) for more details on your options for creating and using a spatially-enabled database.
+
+## Known Issues / Errors
+
+When You encouter errors due to PostGIS update `OperationalError: could not access file "$libdir/postgis-X.X`, run:
+
+`docker exec some-postgis update-postgis.sh`
+
+It will update to Your newest PostGIS. Update is idempotent, so it won't hurt when You run it more than once, You will get notification like:
+
+```
+Updating PostGIS extensions template_postgis to X.X.X
+NOTICE:  version "X.X.X" of extension "postgis" is already installed
+NOTICE:  version "X.X.X" of extension "postgis_topology" is already installed
+NOTICE:  version "X.X.X" of extension "postgis_tiger_geocoder" is already installed
+ALTER EXTENSION
+Updating PostGIS extensions docker to X.X.X
+NOTICE:  version "X.X.X" of extension "postgis" is already installed
+NOTICE:  version "X.X.X" of extension "postgis_topology" is already installed
+NOTICE:  version "X.X.X" of extension "postgis_tiger_geocoder" is already installed
+ALTER EXTENSION
+```
+

--- a/12-2.5/README.md
+++ b/12-2.5/README.md
@@ -1,8 +1,8 @@
-# mdillon/postgis
+# postgis/postgis
 
-[![Build Status](https://travis-ci.org/appropriate/docker-postgis.svg)](https://travis-ci.org/appropriate/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/postgis/docker-postgis.svg)](https://travis-ci.org/postgis/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The `mdillon/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, and Postgres 11.
+The `postgis/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides debian and alpine variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, Postgres 11, and Postgres 12.
 
 This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
 
@@ -17,7 +17,7 @@ Unless `-e POSTGRES_DB` is passed to the container at startup time, this databas
 
 In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
 
-    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d mdillon/postgis
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
 
 For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
 

--- a/12-2.5/alpine/Dockerfile
+++ b/12-2.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:11-alpine
+FROM postgres:12-alpine
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 

--- a/12-2.5/alpine/initdb-postgis.sh
+++ b/12-2.5/alpine/initdb-postgis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis;
+UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/12-2.5/alpine/update-postgis.sh
+++ b/12-2.5/alpine/update-postgis.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+POSTGIS_VERSION="${POSTGIS_VERSION%%+*}"
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB" "${@}"; do
+    echo "Updating PostGIS extensions '$DB' to $POSTGIS_VERSION"
+    psql --dbname="$DB" -c "
+        -- Upgrade PostGIS (includes raster)
+        CREATE EXTENSION IF NOT EXISTS postgis VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis  UPDATE TO '$POSTGIS_VERSION';
+
+        -- Upgrade Topology
+        CREATE EXTENSION IF NOT EXISTS postgis_topology VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_topology UPDATE TO '$POSTGIS_VERSION';
+
+        -- Install Tiger dependencies in case not already installed
+        CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+        -- Upgrade US Tiger Geocoder
+        CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_tiger_geocoder UPDATE TO '$POSTGIS_VERSION';
+    "
+done

--- a/12-2.5/initdb-postgis.sh
+++ b/12-2.5/initdb-postgis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis;
+UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/12-2.5/update-postgis.sh
+++ b/12-2.5/update-postgis.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+POSTGIS_VERSION="${POSTGIS_VERSION%%+*}"
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB" "${@}"; do
+    echo "Updating PostGIS extensions '$DB' to $POSTGIS_VERSION"
+    psql --dbname="$DB" -c "
+        -- Upgrade PostGIS (includes raster)
+        CREATE EXTENSION IF NOT EXISTS postgis VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis  UPDATE TO '$POSTGIS_VERSION';
+
+        -- Upgrade Topology
+        CREATE EXTENSION IF NOT EXISTS postgis_topology VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_topology UPDATE TO '$POSTGIS_VERSION';
+
+        -- Install Tiger dependencies in case not already installed
+        CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+        -- Upgrade US Tiger Geocoder
+        CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_tiger_geocoder UPDATE TO '$POSTGIS_VERSION';
+    "
+done

--- a/9.4-2.5/README.md
+++ b/9.4-2.5/README.md
@@ -1,8 +1,8 @@
-# mdillon/postgis
+# postgis/postgis
 
-[![Build Status](https://travis-ci.org/appropriate/docker-postgis.svg)](https://travis-ci.org/appropriate/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/postgis/docker-postgis.svg)](https://travis-ci.org/postgis/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The `mdillon/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, and Postgres 11.
+The `postgis/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides debian and alpine variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, Postgres 11, and Postgres 12.
 
 This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
 
@@ -17,7 +17,7 @@ Unless `-e POSTGRES_DB` is passed to the container at startup time, this databas
 
 In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
 
-    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d mdillon/postgis
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
 
 For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
 

--- a/9.4-2.5/alpine/Dockerfile
+++ b/9.4-2.5/alpine/Dockerfile
@@ -1,8 +1,9 @@
 FROM postgres:9.4-alpine
-MAINTAINER Régis Belson <me@regisbelson.fr>
 
-ENV POSTGIS_VERSION 2.5.2
-ENV POSTGIS_SHA256 225aeaece00a1a6a9af15526af81bef2af27f4c198de820af1367a792ee1d1a9
+LABEL maintainer="PostGIS Project - https://postgis.net"
+
+ENV POSTGIS_VERSION 2.5.3
+ENV POSTGIS_SHA256 402323c83d97f3859bc9083345dd687f933c261efe0830e1262c20c12671f794
 
 RUN set -ex \
     \
@@ -24,19 +25,19 @@ RUN set -ex \
     && apk add --no-cache --virtual .build-deps \
         autoconf \
         automake \
-        g++ \
+        file \
         json-c-dev \
         libtool \
         libxml2-dev \
         make \
         perl \
-    \
-    && apk add --no-cache --virtual .build-deps-edge \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \    
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        clang-dev \
+        g++ \
+        gcc \
         gdal-dev \
         geos-dev \
-        proj4-dev \
+        llvm9-dev \
+        proj-dev \
         protobuf-c-dev \
     && cd /usr/src/postgis \
     && ./autogen.sh \
@@ -48,16 +49,14 @@ RUN set -ex \
     && make install \
     && apk add --no-cache --virtual .postgis-rundeps \
         json-c \
-    && apk add --no-cache --virtual .postgis-rundeps-edge \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \    
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \        
         geos \
         gdal \
-        proj4 \
+        proj \
+        libstdc++ \
         protobuf-c \
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-edge
+    && apk del .fetch-deps .build-deps
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/9.5-2.5/Dockerfile
+++ b/9.5-2.5/Dockerfile
@@ -1,15 +1,15 @@
 FROM postgres:9.5
-MAINTAINER Mike Dillon <mike@appropriate.io>
+
+LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 2.5
-ENV POSTGIS_VERSION 2.5.2+dfsg-1~exp1.pgdg90+1
+ENV POSTGIS_VERSION 2.5.3+dfsg-3.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
-           postgis=$POSTGIS_VERSION \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/9.5-2.5/README.md
+++ b/9.5-2.5/README.md
@@ -1,8 +1,8 @@
-# mdillon/postgis
+# postgis/postgis
 
-[![Build Status](https://travis-ci.org/appropriate/docker-postgis.svg)](https://travis-ci.org/appropriate/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/postgis/docker-postgis.svg)](https://travis-ci.org/postgis/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The `mdillon/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, and Postgres 11.
+The `postgis/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides debian and alpine variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, Postgres 11, and Postgres 12.
 
 This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
 
@@ -17,7 +17,7 @@ Unless `-e POSTGRES_DB` is passed to the container at startup time, this databas
 
 In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
 
-    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d mdillon/postgis
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
 
 For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
 

--- a/9.5-2.5/alpine/Dockerfile
+++ b/9.5-2.5/alpine/Dockerfile
@@ -1,8 +1,9 @@
 FROM postgres:9.5-alpine
-MAINTAINER Régis Belson <me@regisbelson.fr>
 
-ENV POSTGIS_VERSION 2.5.2
-ENV POSTGIS_SHA256 225aeaece00a1a6a9af15526af81bef2af27f4c198de820af1367a792ee1d1a9
+LABEL maintainer="PostGIS Project - https://postgis.net"
+
+ENV POSTGIS_VERSION 2.5.3
+ENV POSTGIS_SHA256 402323c83d97f3859bc9083345dd687f933c261efe0830e1262c20c12671f794
 
 RUN set -ex \
     \
@@ -24,19 +25,19 @@ RUN set -ex \
     && apk add --no-cache --virtual .build-deps \
         autoconf \
         automake \
-        g++ \
+        file \
         json-c-dev \
         libtool \
         libxml2-dev \
         make \
         perl \
-    \
-    && apk add --no-cache --virtual .build-deps-edge \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \    
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        clang-dev \
+        g++ \
+        gcc \
         gdal-dev \
         geos-dev \
-        proj4-dev \
+        llvm9-dev \
+        proj-dev \
         protobuf-c-dev \
     && cd /usr/src/postgis \
     && ./autogen.sh \
@@ -48,16 +49,14 @@ RUN set -ex \
     && make install \
     && apk add --no-cache --virtual .postgis-rundeps \
         json-c \
-    && apk add --no-cache --virtual .postgis-rundeps-edge \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \    
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \        
         geos \
         gdal \
-        proj4 \
+        proj \
+        libstdc++ \
         protobuf-c \
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-edge
+    && apk del .fetch-deps .build-deps
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/9.6-2.5/Dockerfile
+++ b/9.6-2.5/Dockerfile
@@ -1,15 +1,15 @@
 FROM postgres:9.6
-MAINTAINER Mike Dillon <mike@appropriate.io>
+
+LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 2.5
-ENV POSTGIS_VERSION 2.5.2+dfsg-1~exp1.pgdg90+1
+ENV POSTGIS_VERSION 2.5.3+dfsg-3.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
-           postgis=$POSTGIS_VERSION \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/9.6-2.5/README.md
+++ b/9.6-2.5/README.md
@@ -1,8 +1,8 @@
-# mdillon/postgis
+# postgis/postgis
 
-[![Build Status](https://travis-ci.org/appropriate/docker-postgis.svg)](https://travis-ci.org/appropriate/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/postgis/docker-postgis.svg)](https://travis-ci.org/postgis/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The `mdillon/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, and Postgres 11.
+The `postgis/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides debian and alpine variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, Postgres 11, and Postgres 12.
 
 This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
 
@@ -17,7 +17,7 @@ Unless `-e POSTGRES_DB` is passed to the container at startup time, this databas
 
 In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
 
-    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d mdillon/postgis
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
 
 For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
 

--- a/9.6-2.5/alpine/Dockerfile
+++ b/9.6-2.5/alpine/Dockerfile
@@ -1,8 +1,9 @@
 FROM postgres:9.6-alpine
-MAINTAINER Régis Belson <me@regisbelson.fr>
 
-ENV POSTGIS_VERSION 2.5.2
-ENV POSTGIS_SHA256 225aeaece00a1a6a9af15526af81bef2af27f4c198de820af1367a792ee1d1a9
+LABEL maintainer="PostGIS Project - https://postgis.net"
+
+ENV POSTGIS_VERSION 2.5.3
+ENV POSTGIS_SHA256 402323c83d97f3859bc9083345dd687f933c261efe0830e1262c20c12671f794
 
 RUN set -ex \
     \
@@ -24,19 +25,19 @@ RUN set -ex \
     && apk add --no-cache --virtual .build-deps \
         autoconf \
         automake \
-        g++ \
+        file \
         json-c-dev \
         libtool \
         libxml2-dev \
         make \
         perl \
-    \
-    && apk add --no-cache --virtual .build-deps-edge \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \    
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        clang-dev \
+        g++ \
+        gcc \
         gdal-dev \
         geos-dev \
-        proj4-dev \
+        llvm9-dev \
+        proj-dev \
         protobuf-c-dev \
     && cd /usr/src/postgis \
     && ./autogen.sh \
@@ -48,16 +49,14 @@ RUN set -ex \
     && make install \
     && apk add --no-cache --virtual .postgis-rundeps \
         json-c \
-    && apk add --no-cache --virtual .postgis-rundeps-edge \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \    
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \        
         geos \
         gdal \
-        proj4 \
+        proj \
+        libstdc++ \
         protobuf-c \
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-edge
+    && apk del .fetch-deps .build-deps
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# mdillon/postgis
+# postgis/postgis
 
-[![Build Status](https://travis-ci.org/appropriate/docker-postgis.svg)](https://travis-ci.org/appropriate/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/postgis/docker-postgis.svg)](https://travis-ci.org/postgis/docker-postgis) [![Join the chat at https://gitter.im/appropriate/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/appropriate/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The `mdillon/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, and Postgres 11.
+The `postgis/postgis` image provides a Docker container running Postgres with [PostGIS 2.5](http://postgis.net/) installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides debian and alpine variants for each version of Postgres 9 supported by the base image (9.4-9.6), Postgres 10, Postgres 11, and Postgres 12.
 
 This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
 
@@ -17,7 +17,7 @@ Unless `-e POSTGRES_DB` is passed to the container at startup time, this databas
 
 In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
 
-    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d mdillon/postgis
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
 
 For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
 


### PR DESCRIPTION
- Updated Travis to build with Xenial instead of Trusty
- Updated images from PostGIS v2.5.2 to v2.5.3
- Added PostgreSQL v12 images
- Swapped out Dockerfile MAINTAINER instructions (which are now deprecated) and replaced with LABEL instructions
  with maintainer keys