### PR TITLE
Add docker build --pull | "Always attempt to pull a newer version of the image"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ build: $(VERSIONS)
 
 define postgis-version
 $1:
-	docker build -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) $1
-	docker build -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine $1/alpine
+	docker build --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) $1
+	docker build --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine $1/alpine
 endef
 $(foreach version,$(VERSIONS),$(eval $(call postgis-version,$(version))))
 


### PR DESCRIPTION
imho: it will be useful to add `--pull` option - to [`docker build`](https://docs.docker.com/engine/reference/commandline/build/) - for  less-experienced users.
( based on my  experience -  with supporting new users https://github.com/postgis/docker-postgis/issues/168#issuecomment-585530438  )