### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This image ensures that the default database created by the parent `postgres` im
 
 * `postgis`
 * `postgis_topology`
-* `fuzzystrmatch`
 * `postgis_tiger_geocoder`
+
+Note: As of PostGIS v3.x, raster has been factored out into a separate extension `postgis_raster` which must be installed separately.
 
 Unless `-e POSTGRES_DB` is passed to the container at startup time, this database will be named after the admin user (either `postgres` or the user specified with `-e POSTGRES_USER`). If you would prefer to use the older template database mechanism for enabling PostGIS, the image also provides a PostGIS-enabled template database called `template_postgis`.
 


### PR DESCRIPTION
postgis_raster got broken out as a separate extension in PostGIS 3.0, so should be noted in the readme