### PR TITLE
update to postgis 3.1.2

### DIFF
--- a/10-3.1/Dockerfile
+++ b/10-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:10
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.1+dfsg-1.pgdg90+1
+ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/10-3.1/alpine/Dockerfile
+++ b/10-3.1/alpine/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:10-alpine
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
-ENV POSTGIS_VERSION 3.1.1
-ENV POSTGIS_SHA256 28e9cb33d5a762ad2aa72513a05183bf45416ba7de2316ff3ad0da60c4ce56e3
+ENV POSTGIS_VERSION 3.1.2
+ENV POSTGIS_SHA256 c49b6baa4afe4aed6cc7333399897aaf7540b40779a939a4d5a81d0725f6c9f8
 
 RUN set -ex \
     \

--- a/11-3.1/Dockerfile
+++ b/11-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:11
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.1+dfsg-1.pgdg90+1
+ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/11-3.1/alpine/Dockerfile
+++ b/11-3.1/alpine/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:11-alpine
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
-ENV POSTGIS_VERSION 3.1.1
-ENV POSTGIS_SHA256 28e9cb33d5a762ad2aa72513a05183bf45416ba7de2316ff3ad0da60c4ce56e3
+ENV POSTGIS_VERSION 3.1.2
+ENV POSTGIS_SHA256 c49b6baa4afe4aed6cc7333399897aaf7540b40779a939a4d5a81d0725f6c9f8
 
 RUN set -ex \
     \

--- a/12-3.1/Dockerfile
+++ b/12-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:12
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.1+dfsg-1.pgdg100+1
+ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg100+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/12-3.1/alpine/Dockerfile
+++ b/12-3.1/alpine/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:12-alpine
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
-ENV POSTGIS_VERSION 3.1.1
-ENV POSTGIS_SHA256 28e9cb33d5a762ad2aa72513a05183bf45416ba7de2316ff3ad0da60c4ce56e3
+ENV POSTGIS_VERSION 3.1.2
+ENV POSTGIS_SHA256 c49b6baa4afe4aed6cc7333399897aaf7540b40779a939a4d5a81d0725f6c9f8
 
 RUN set -ex \
     \

--- a/13-3.1/Dockerfile
+++ b/13-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:13
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.1+dfsg-1.pgdg100+1
+ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg100+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/13-3.1/alpine/Dockerfile
+++ b/13-3.1/alpine/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:13-alpine
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
-ENV POSTGIS_VERSION 3.1.1
-ENV POSTGIS_SHA256 28e9cb33d5a762ad2aa72513a05183bf45416ba7de2316ff3ad0da60c4ce56e3
+ENV POSTGIS_VERSION 3.1.2
+ENV POSTGIS_SHA256 c49b6baa4afe4aed6cc7333399897aaf7540b40779a939a4d5a81d0725f6c9f8
 
 RUN set -ex \
     \

--- a/9.6-3.1/Dockerfile
+++ b/9.6-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:9.6
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.1+dfsg-1.pgdg90+1
+ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/9.6-3.1/alpine/Dockerfile
+++ b/9.6-3.1/alpine/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:9.6-alpine
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
-ENV POSTGIS_VERSION 3.1.1
-ENV POSTGIS_SHA256 28e9cb33d5a762ad2aa72513a05183bf45416ba7de2316ff3ad0da60c4ce56e3
+ENV POSTGIS_VERSION 3.1.2
+ENV POSTGIS_SHA256 c49b6baa4afe4aed6cc7333399897aaf7540b40779a939a4d5a81d0725f6c9f8
 
 RUN set -ex \
     \


### PR DESCRIPTION
* generated by `make update`
* triggered by "_postgis updated to version 3.1.2+dfsg-1~exp2.pgdg+1"_  ( 2021-05-31 13:34:17 )
  *  https://www.postgresql.org/message-id/E1lni3d-0004Cv-Q8%40atalia.postgresql.org
* if the CI/CD is OK ... ready to merge

