### PR TITLE
add postgis/postgis:14beta2-3.1 versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,17 @@ defaults:
     shell: bash
 
 jobs:
-  
+
   make-docker-images:
     strategy:
       matrix:
-        postgres: [9.6, 10, 11, 12, 13]
+        postgres: [9.6, 10, 11, 12, 13, '14beta2']
         postgis: ['2.5', '3.1']
         variant: [default, alpine]
         exclude:
           - postgres: 13
+            postgis: '2.5'
+          - postgres: '14beta2'
             postgis: '2.5'
         include:
           - postgres: 12

--- a/12-master/Dockerfile
+++ b/12-master/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH d41c10c9e1e787a521a3841605a2e6024649eb3f
+ENV PROJ_GIT_HASH d902272785a55e48f6b46a907a34a71a5220fccc
 
 RUN set -ex \
     && cd /usr/src \
@@ -95,7 +95,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH cb127eeac823c8b48364c1b437844a5b65ff4748
+ENV GEOS_GIT_HASH 1bfc5b27493c552fd9a28823358a4c1f4c3b65f7
 
 RUN set -ex \
     && cd /usr/src \
@@ -112,7 +112,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH d7ae1604aabf4aa7fbf955f8913a4a892927b60d
+ENV GDAL_GIT_HASH 51e564e9364243be48da5e264c0507d7a9c546d8
 
 RUN set -ex \
     && cd /usr/src \
@@ -171,9 +171,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 ENV SFCGAL_GIT_HASH e4fcf6b2e166a862db568a0419fe100849d3f447
-ENV PROJ_GIT_HASH d41c10c9e1e787a521a3841605a2e6024649eb3f
-ENV GEOS_GIT_HASH cb127eeac823c8b48364c1b437844a5b65ff4748
-ENV GDAL_GIT_HASH d7ae1604aabf4aa7fbf955f8913a4a892927b60d
+ENV PROJ_GIT_HASH d902272785a55e48f6b46a907a34a71a5220fccc
+ENV GEOS_GIT_HASH 1bfc5b27493c552fd9a28823358a4c1f4c3b65f7
+ENV GDAL_GIT_HASH 51e564e9364243be48da5e264c0507d7a9c546d8
 
 # Minimal command line test.
 RUN set -ex \
@@ -187,7 +187,7 @@ RUN set -ex \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH e2d34f1190d0a1de352de455fcb5352df8997ace
+ENV POSTGIS_GIT_HASH 54a0c748dbb165847c1d0fe3abbe22dd48b8237a
 
 RUN set -ex \
     && apt-get update \

--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH d41c10c9e1e787a521a3841605a2e6024649eb3f
+ENV PROJ_GIT_HASH d902272785a55e48f6b46a907a34a71a5220fccc
 
 RUN set -ex \
     && cd /usr/src \
@@ -95,7 +95,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH cb127eeac823c8b48364c1b437844a5b65ff4748
+ENV GEOS_GIT_HASH 1bfc5b27493c552fd9a28823358a4c1f4c3b65f7
 
 RUN set -ex \
     && cd /usr/src \
@@ -112,7 +112,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH d7ae1604aabf4aa7fbf955f8913a4a892927b60d
+ENV GDAL_GIT_HASH 51e564e9364243be48da5e264c0507d7a9c546d8
 
 RUN set -ex \
     && cd /usr/src \
@@ -171,9 +171,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 ENV SFCGAL_GIT_HASH e4fcf6b2e166a862db568a0419fe100849d3f447
-ENV PROJ_GIT_HASH d41c10c9e1e787a521a3841605a2e6024649eb3f
-ENV GEOS_GIT_HASH cb127eeac823c8b48364c1b437844a5b65ff4748
-ENV GDAL_GIT_HASH d7ae1604aabf4aa7fbf955f8913a4a892927b60d
+ENV PROJ_GIT_HASH d902272785a55e48f6b46a907a34a71a5220fccc
+ENV GEOS_GIT_HASH 1bfc5b27493c552fd9a28823358a4c1f4c3b65f7
+ENV GDAL_GIT_HASH 51e564e9364243be48da5e264c0507d7a9c546d8
 
 # Minimal command line test.
 RUN set -ex \
@@ -187,7 +187,7 @@ RUN set -ex \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH e2d34f1190d0a1de352de455fcb5352df8997ace
+ENV POSTGIS_GIT_HASH 54a0c748dbb165847c1d0fe3abbe22dd48b8237a
 
 RUN set -ex \
     && apt-get update \

--- a/14beta2-3.1/Dockerfile
+++ b/14beta2-3.1/Dockerfile
@@ -1,0 +1,18 @@
+FROM postgres:14beta2
+
+LABEL maintainer="PostGIS Project - https://postgis.net"
+
+ENV POSTGIS_MAJOR 3
+ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg100+1
+
+RUN apt-get update \
+      && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
+      && apt-get install -y --no-install-recommends \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+      && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
+COPY ./update-postgis.sh /usr/local/bin
+

--- a/14beta2-3.1/README.md
+++ b/14beta2-3.1/README.md
@@ -1,0 +1,63 @@
+# postgis/postgis
+
+[![Build Status](https://github.com/postgis/docker-postgis/workflows/Docker%20PostGIS%20CI/badge.svg)](https://github.com/postgis/docker-postgis/actions) [![Join the chat at https://gitter.im/postgis/docker-postgis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/postgis/docker-postgis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+The `postgis/postgis` image provides tags for running Postgres with [PostGIS](http://postgis.net/) extensions installed. This image is based on the official [`postgres`](https://registry.hub.docker.com/_/postgres/) image and provides debian and alpine variants for PostGIS both 2.5.x and 3.1.x for each supported version of Postgres (9.5, 9.6, 10, 11, 12 and 13).  Additionally, an image version is provided which is built from the latest version of Postgres (13) with versions of PostGIS and its dependencies built from their respective master branches.
+
+This image ensures that the default database created by the parent `postgres` image will have the following extensions installed:
+
+* `postgis`
+* `postgis_topology`
+* `postgis_tiger_geocoder`
+
+Note: As of PostGIS v3.x, raster has been factored out into a separate extension `postgis_raster` which must be installed separately.
+
+Unless `-e POSTGRES_DB` is passed to the container at startup time, this database will be named after the admin user (either `postgres` or the user specified with `-e POSTGRES_USER`). If you would prefer to use the older template database mechanism for enabling PostGIS, the image also provides a PostGIS-enabled template database called `template_postgis`.
+
+## Usage
+
+In order to run a basic container capable of serving a PostGIS-enabled database, start a container as follows:
+
+    docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
+
+For more detailed instructions about how to start and control your Postgres container, see the documentation for the `postgres` image [here](https://registry.hub.docker.com/_/postgres/).
+
+Once you have started a database container, you can then connect to the database either directly on the running container:
+
+    docker exec -ti some-postgis psql -U postgres
+    
+... or starting a new container to run as a client. In this case you can use a user-defined network to link both containers:
+
+    docker network create some-network
+    
+    # Server container
+    docker run --name some-postgis --network some-network -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis
+    
+    # Client container
+    docker run -it --rm --network some-network postgis/postgis psql -h some-postgis -U postgres
+    
+Check the documentation on the [`postgres` image](https://registry.hub.docker.com/_/postgres/) and [Docker networking](https://docs.docker.com/network/) for more details and alternatives on connecting different containers.
+
+See [the PostGIS documentation](http://postgis.net/docs/postgis_installation.html#create_new_db_extensions) for more details on your options for creating and using a spatially-enabled database.
+
+## Known Issues / Errors
+
+When You encouter errors due to PostGIS update `OperationalError: could not access file "$libdir/postgis-X.X`, run:
+
+`docker exec some-postgis update-postgis.sh`
+
+It will update to Your newest PostGIS. Update is idempotent, so it won't hurt when You run it more than once, You will get notification like:
+
+```
+Updating PostGIS extensions template_postgis to X.X.X
+NOTICE:  version "X.X.X" of extension "postgis" is already installed
+NOTICE:  version "X.X.X" of extension "postgis_topology" is already installed
+NOTICE:  version "X.X.X" of extension "postgis_tiger_geocoder" is already installed
+ALTER EXTENSION
+Updating PostGIS extensions docker to X.X.X
+NOTICE:  version "X.X.X" of extension "postgis" is already installed
+NOTICE:  version "X.X.X" of extension "postgis_topology" is already installed
+NOTICE:  version "X.X.X" of extension "postgis_tiger_geocoder" is already installed
+ALTER EXTENSION
+```
+

--- a/14beta2-3.1/alpine/Dockerfile
+++ b/14beta2-3.1/alpine/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:14beta2-alpine
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
-ENV POSTGIS_VERSION 3.1.2
-ENV POSTGIS_SHA256 c49b6baa4afe4aed6cc7333399897aaf7540b40779a939a4d5a81d0725f6c9f8
+ENV POSTGIS_VERSION 3.1.3
+ENV POSTGIS_SHA256 885e11b26d8385aff49e605d33749a83e711180a3b1996395564ddf6346f3bb4
 
 #Temporary fix:
 #   for PostGIS 2.* - building a special geos

--- a/14beta2-3.1/alpine/Dockerfile
+++ b/14beta2-3.1/alpine/Dockerfile
@@ -1,0 +1,110 @@
+FROM postgres:14beta2-alpine
+
+LABEL maintainer="PostGIS Project - https://postgis.net"
+
+ENV POSTGIS_VERSION 3.1.2
+ENV POSTGIS_SHA256 c49b6baa4afe4aed6cc7333399897aaf7540b40779a939a4d5a81d0725f6c9f8
+
+#Temporary fix:
+#   for PostGIS 2.* - building a special geos
+#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
+ENV POSTGIS2_GEOS_VERSION tags/3.8.2
+
+RUN set -eux \
+    \
+    && apk add --no-cache --virtual .fetch-deps \
+        ca-certificates \
+        openssl \
+        tar \
+    \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
+    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/src/postgis \
+    && tar \
+        --extract \
+        --file postgis.tar.gz \
+        --directory /usr/src/postgis \
+        --strip-components 1 \
+    && rm postgis.tar.gz \
+    \
+    && apk add --no-cache --virtual .build-deps \
+        autoconf \
+        automake \
+        clang-dev \
+        file \
+        g++ \
+        gcc \
+        gdal-dev \
+        gettext-dev \
+        json-c-dev \
+        libtool \
+        libxml2-dev \
+        llvm11-dev \
+        make \
+        pcre-dev \
+        perl \
+        proj-dev \
+        protobuf-c-dev \
+     \
+# GEOS setup
+     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            apk add --no-cache --virtual .build-deps-geos cmake git ; \
+            cd /usr/src ; \
+            git clone https://github.com/libgeos/geos.git ; \
+            cd geos ; \
+            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
+            mkdir cmake-build ; \
+            cd cmake-build ; \
+                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
+                make -j$(nproc) ; \
+                make check ; \
+                make install ; \
+            cd / ; \
+            rm -fr /usr/src/geos ; \
+        else \
+            echo ".... unknown PosGIS ...." ; \
+        fi \
+    \
+# build PostGIS
+    \
+    && cd /usr/src/postgis \
+    && gettextize \
+    && ./autogen.sh \
+    && ./configure \
+        --with-pcredir="$(pcre-config --prefix)" \
+    && make -j$(nproc) \
+    && make install \
+    \
+# regress check
+    && mkdir /tempdb \
+    && chown -R postgres:postgres /tempdb \
+    && su postgres -c 'pg_ctl -D /tempdb init' \
+    && su postgres -c 'pg_ctl -D /tempdb start' \
+    && cd regress \
+    && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
+    #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
+    #&& make garden                                      PGUSER=postgres \
+    && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
+    && rm -rf /tempdb \
+    && rm -rf /tmp/pgis_reg \
+# add .postgis-rundeps
+    && apk add --no-cache --virtual .postgis-rundeps \
+        gdal \
+        json-c \
+        libstdc++ \
+        pcre \
+        proj \
+        protobuf-c \
+     # Geos setup
+     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
+        fi \
+# clean
+    && cd / \
+    && rm -rf /usr/src/postgis \
+    && apk del .fetch-deps .build-deps .build-deps-geos
+
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
+COPY ./update-postgis.sh /usr/local/bin

--- a/14beta2-3.1/alpine/initdb-postgis.sh
+++ b/14beta2-3.1/alpine/initdb-postgis.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis IS_TEMPLATE true;
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/14beta2-3.1/alpine/update-postgis.sh
+++ b/14beta2-3.1/alpine/update-postgis.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+POSTGIS_VERSION="${POSTGIS_VERSION%%+*}"
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB" "${@}"; do
+    echo "Updating PostGIS extensions '$DB' to $POSTGIS_VERSION"
+    psql --dbname="$DB" -c "
+        -- Upgrade PostGIS (includes raster)
+        CREATE EXTENSION IF NOT EXISTS postgis VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis  UPDATE TO '$POSTGIS_VERSION';
+
+        -- Upgrade Topology
+        CREATE EXTENSION IF NOT EXISTS postgis_topology VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_topology UPDATE TO '$POSTGIS_VERSION';
+
+        -- Install Tiger dependencies in case not already installed
+        CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+        -- Upgrade US Tiger Geocoder
+        CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_tiger_geocoder UPDATE TO '$POSTGIS_VERSION';
+    "
+done

--- a/14beta2-3.1/initdb-postgis.sh
+++ b/14beta2-3.1/initdb-postgis.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis IS_TEMPLATE true;
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/14beta2-3.1/update-postgis.sh
+++ b/14beta2-3.1/update-postgis.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+POSTGIS_VERSION="${POSTGIS_VERSION%%+*}"
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB" "${@}"; do
+    echo "Updating PostGIS extensions '$DB' to $POSTGIS_VERSION"
+    psql --dbname="$DB" -c "
+        -- Upgrade PostGIS (includes raster)
+        CREATE EXTENSION IF NOT EXISTS postgis VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis  UPDATE TO '$POSTGIS_VERSION';
+
+        -- Upgrade Topology
+        CREATE EXTENSION IF NOT EXISTS postgis_topology VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_topology UPDATE TO '$POSTGIS_VERSION';
+
+        -- Install Tiger dependencies in case not already installed
+        CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+        -- Upgrade US Tiger Geocoder
+        CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_tiger_geocoder UPDATE TO '$POSTGIS_VERSION';
+    "
+done

--- a/update.sh
+++ b/update.sh
@@ -21,12 +21,14 @@ declare -A debianSuite=(
     [11]='stretch-slim'
     [12]='buster-slim'
     [13]='buster-slim'
+    [14]='buster-slim'
+    [14beta2]='buster-slim'
 )
 
 defaultPostgisDebPkgNameVersionSuffix='3'
 declare -A postgisDebPkgNameVersionSuffixes=(
     [2.5]='2.5'
-    [3.0]='3'    
+    [3.0]='3'
     [3.1]='3'
 )
 
@@ -35,8 +37,8 @@ packagesBase='http://apt.postgresql.org/pub/repos/apt/dists/'
 sfcgalGitHash="$(git ls-remote https://gitlab.com/Oslandia/SFCGAL.git heads/master | awk '{ print $1}')"
 projGitHash="$(git ls-remote https://github.com/OSGeo/PROJ.git heads/master | awk '{ print $1}')"
 gdalGitHash="$(git ls-remote https://github.com/OSGeo/gdal.git refs/heads/master | grep '\srefs/heads/master' | awk '{ print $1}')"
-geosGitHash="$(git ls-remote https://github.com/libgeos/geos.git heads/master | awk '{ print $1}')"
-postgisGitHash="$(git ls-remote https://git.osgeo.org/gitea/postgis/postgis.git heads/master | awk '{ print $1}')"
+geosGitHash="$(git ls-remote https://github.com/libgeos/geos.git heads/main | awk '{ print $1}')"
+postgisGitHash="$(git ls-remote https://git.osgeo.org/gitea/postgis/postgis.git heads/main | awk '{ print $1}')"
 
 declare -A suitePackageList=() suiteArches=()
 travisEnv=
@@ -53,8 +55,9 @@ for version in "${versions[@]}"; do
         suiteArches["$suite"]="$(curl -fsSL "${packagesBase}/${suite}-pgdg/Release" | awk -F ':[[:space:]]+' '$1 == "Architectures" { gsub(/[[:space:]]+/, "|", $2); print $2 }')"
     fi
 
-    versionList="$(echo "${suitePackageList["$suite"]}"; curl -fsSL "${packagesBase}/${suite}-pgdg/${postgresVersion}/binary-amd64/Packages.bz2" | bunzip2)"
-    fullVersion="$(echo "$versionList" | awk -F ': ' '$1 == "Package" { pkg = $2 } $1 == "Version" && pkg == "postgresql-'"$postgresVersion"'" { print $2; exit }' || true)"
+    postgresVersionMain="$(echo "$postgresVersion" | awk -F 'beta' '{print $1}')"
+    versionList="$(echo "${suitePackageList["$suite"]}"; curl -fsSL "${packagesBase}/${suite}-pgdg/${postgresVersionMain}/binary-amd64/Packages.bz2" | bunzip2)"
+    fullVersion="$(echo "$versionList" | awk -F ': ' '$1 == "Package" { pkg = $2 } $1 == "Version" && pkg == "postgresql-'"$postgresVersionMain"'" { print $2; exit }' || true)"
     majorVersion="${postgresVersion%%.*}"
 
     if [ "$suite" = "stretch" ]; then
@@ -70,7 +73,7 @@ for version in "${versions[@]}"; do
         postgisFullVersion="$postgisVersion"
         postgisMajor=""
     else
-        postgisPackageName="postgresql-${postgresVersion}-postgis-${postgisDebPkgNameVersionSuffixes[${postgisVersion}]}"
+        postgisPackageName="postgresql-${postgresVersionMain}-postgis-${postgisDebPkgNameVersionSuffixes[${postgisVersion}]}"
         postgisFullVersion="$(echo "$versionList" | awk -F ': ' '$1 == "Package" { pkg = $2 } $1 == "Version" && pkg == "'"$postgisPackageName"'" { print $2; exit }' || true)"
         postgisMajor="${postgisDebPkgNameVersionSuffixes[${postgisVersion}]}"
     fi


### PR DESCRIPTION
adding a new Postgres 14beta2 versions

* Important ! Now:  [no "postgres:14" images; only "postgres:14beta2" and "postgres:14beta2-alpine"](https://hub.docker.com/_/postgres?tab=tags&page=1&ordering=last_updated )  so I have made some quick&dirty changes.
    The Postgres-betas internal format can be changed; so the new tagging is better for the users.
    related: https://github.com/postgis/docker-postgis/issues/228
       * _"The database cluster was initialized with CATALOG_VERSION_NO  ....  , but the server was compiled with ...."_
    
* I have updated some upstream git source `master` branch to `main`.

* Manually updated the alpine files to 3.1.3  ( The Debian PostGIS is still on 3.1.2, but this is not enough )
   * see: https://postgis.net/2021/07/02/postgis-3.1.3/
   * IMPORTANT:  after every `./update.sh` - we need manually update to Alpine to 3.1.3 ( avoiding FuncnameGetCandidates errors )

------------------
   
Other notes:
* The upstream https://github.com/docker-library/postgres project - implemented a new jq-based templating engine ( https://github.com/docker-library/postgres/pull/852 )  .. so I think my beta2 dirty code is not final .. we need to follow the upstream ..
    * example: the [docker ruby 3.0](https://github.com/docker-library/ruby/tree/master/3.0) version now has 4 different docker image versions! 
       *  `alpine3.13`,`alpine3.14`,`buster`,`slim-buster`