### PR TITLE
make update 2021-Aug-19

### DIFF
--- a/10-2.5/Dockerfile
+++ b/10-2.5/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/10-3.1/Dockerfile
+++ b/10-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:10
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg90+1
+ENV POSTGIS_VERSION 3.1.3+dfsg-1~exp1.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/10-3.1/Dockerfile
+++ b/10-3.1/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/11-2.5/Dockerfile
+++ b/11-2.5/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/11-3.1/Dockerfile
+++ b/11-3.1/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/11-3.1/Dockerfile
+++ b/11-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:11
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg90+1
+ENV POSTGIS_VERSION 3.1.3+dfsg-1~exp1.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/12-2.5/Dockerfile
+++ b/12-2.5/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/12-3.1/Dockerfile
+++ b/12-3.1/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/12-3.1/Dockerfile
+++ b/12-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:12
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg100+1
+ENV POSTGIS_VERSION 3.1.3+dfsg-1~exp1.pgdg100+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/12-master/Dockerfile
+++ b/12-master/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 7063808658c11296eb9e49ffe3ba157b60043026
+ENV PROJ_GIT_HASH 4766b7c3a17dc98f99c59d2b64076fd924df5804
 
 RUN set -ex \
     && cd /usr/src \
@@ -95,7 +95,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 16610691611decd2b9545ea68ef41e8b94f859e6
+ENV GEOS_GIT_HASH 511bb3f2cf2d2f8bcf581cd101f350047aa97a35
 
 RUN set -ex \
     && cd /usr/src \
@@ -112,7 +112,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 7fbaca67612f8b672055069c83db18c5beeb8f80
+ENV GDAL_GIT_HASH 93be20bff7e076ee2ec57107523383fd214e15df
 
 RUN set -ex \
     && cd /usr/src \
@@ -171,9 +171,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
-ENV PROJ_GIT_HASH 7063808658c11296eb9e49ffe3ba157b60043026
-ENV GEOS_GIT_HASH 16610691611decd2b9545ea68ef41e8b94f859e6
-ENV GDAL_GIT_HASH 7fbaca67612f8b672055069c83db18c5beeb8f80
+ENV PROJ_GIT_HASH 4766b7c3a17dc98f99c59d2b64076fd924df5804
+ENV GEOS_GIT_HASH 511bb3f2cf2d2f8bcf581cd101f350047aa97a35
+ENV GDAL_GIT_HASH 93be20bff7e076ee2ec57107523383fd214e15df
 
 # Minimal command line test.
 RUN set -ex \
@@ -187,7 +187,7 @@ RUN set -ex \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 9ee72d5cb6e9b049c1b048f77d28140e18b18504
+ENV POSTGIS_GIT_HASH 0485c13d40a0d57e56275d89faef987a7a673518
 
 RUN set -ex \
     && apt-get update \

--- a/12-master/Dockerfile
+++ b/12-master/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 4766b7c3a17dc98f99c59d2b64076fd924df5804
+ENV PROJ_GIT_HASH 6ee8c26b60e99e347dad8b7d6fb33b5316973f9d
 
 RUN set -ex \
     && cd /usr/src \
@@ -112,7 +112,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 93be20bff7e076ee2ec57107523383fd214e15df
+ENV GDAL_GIT_HASH 4efc764d666b23243fae9a1dc8a82e33324bfdfa
 
 RUN set -ex \
     && cd /usr/src \
@@ -171,9 +171,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
-ENV PROJ_GIT_HASH 4766b7c3a17dc98f99c59d2b64076fd924df5804
+ENV PROJ_GIT_HASH 6ee8c26b60e99e347dad8b7d6fb33b5316973f9d
 ENV GEOS_GIT_HASH 511bb3f2cf2d2f8bcf581cd101f350047aa97a35
-ENV GDAL_GIT_HASH 93be20bff7e076ee2ec57107523383fd214e15df
+ENV GDAL_GIT_HASH 4efc764d666b23243fae9a1dc8a82e33324bfdfa
 
 # Minimal command line test.
 RUN set -ex \
@@ -187,7 +187,7 @@ RUN set -ex \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 0485c13d40a0d57e56275d89faef987a7a673518
+ENV POSTGIS_GIT_HASH 86a8a59791431b279e4d6511c96af0d3e45332d5
 
 RUN set -ex \
     && apt-get update \

--- a/13-3.1/Dockerfile
+++ b/13-3.1/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/13-3.1/Dockerfile
+++ b/13-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:13
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg100+1
+ENV POSTGIS_VERSION 3.1.3+dfsg-1~exp1.pgdg100+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 7063808658c11296eb9e49ffe3ba157b60043026
+ENV PROJ_GIT_HASH 4766b7c3a17dc98f99c59d2b64076fd924df5804
 
 RUN set -ex \
     && cd /usr/src \
@@ -95,7 +95,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 16610691611decd2b9545ea68ef41e8b94f859e6
+ENV GEOS_GIT_HASH 511bb3f2cf2d2f8bcf581cd101f350047aa97a35
 
 RUN set -ex \
     && cd /usr/src \
@@ -112,7 +112,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 7fbaca67612f8b672055069c83db18c5beeb8f80
+ENV GDAL_GIT_HASH 93be20bff7e076ee2ec57107523383fd214e15df
 
 RUN set -ex \
     && cd /usr/src \
@@ -171,9 +171,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
-ENV PROJ_GIT_HASH 7063808658c11296eb9e49ffe3ba157b60043026
-ENV GEOS_GIT_HASH 16610691611decd2b9545ea68ef41e8b94f859e6
-ENV GDAL_GIT_HASH 7fbaca67612f8b672055069c83db18c5beeb8f80
+ENV PROJ_GIT_HASH 4766b7c3a17dc98f99c59d2b64076fd924df5804
+ENV GEOS_GIT_HASH 511bb3f2cf2d2f8bcf581cd101f350047aa97a35
+ENV GDAL_GIT_HASH 93be20bff7e076ee2ec57107523383fd214e15df
 
 # Minimal command line test.
 RUN set -ex \
@@ -187,7 +187,7 @@ RUN set -ex \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 9ee72d5cb6e9b049c1b048f77d28140e18b18504
+ENV POSTGIS_GIT_HASH 0485c13d40a0d57e56275d89faef987a7a673518
 
 RUN set -ex \
     && apt-get update \

--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 4766b7c3a17dc98f99c59d2b64076fd924df5804
+ENV PROJ_GIT_HASH 6ee8c26b60e99e347dad8b7d6fb33b5316973f9d
 
 RUN set -ex \
     && cd /usr/src \
@@ -112,7 +112,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 93be20bff7e076ee2ec57107523383fd214e15df
+ENV GDAL_GIT_HASH 4efc764d666b23243fae9a1dc8a82e33324bfdfa
 
 RUN set -ex \
     && cd /usr/src \
@@ -171,9 +171,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
-ENV PROJ_GIT_HASH 4766b7c3a17dc98f99c59d2b64076fd924df5804
+ENV PROJ_GIT_HASH 6ee8c26b60e99e347dad8b7d6fb33b5316973f9d
 ENV GEOS_GIT_HASH 511bb3f2cf2d2f8bcf581cd101f350047aa97a35
-ENV GDAL_GIT_HASH 93be20bff7e076ee2ec57107523383fd214e15df
+ENV GDAL_GIT_HASH 4efc764d666b23243fae9a1dc8a82e33324bfdfa
 
 # Minimal command line test.
 RUN set -ex \
@@ -187,7 +187,7 @@ RUN set -ex \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 0485c13d40a0d57e56275d89faef987a7a673518
+ENV POSTGIS_GIT_HASH 86a8a59791431b279e4d6511c96af0d3e45332d5
 
 RUN set -ex \
     && apt-get update \

--- a/14beta3-3.1/Dockerfile
+++ b/14beta3-3.1/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/14beta3-3.1/Dockerfile
+++ b/14beta3-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:14beta3
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg100+1
+ENV POSTGIS_VERSION 3.1.3+dfsg-1~exp1.pgdg100+1+b1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/9.6-2.5/Dockerfile
+++ b/9.6-2.5/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/9.6-3.1/Dockerfile
+++ b/9.6-3.1/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d

--- a/9.6-3.1/Dockerfile
+++ b/9.6-3.1/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:9.6
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.2+dfsg-1~exp2.pgdg90+1
+ENV POSTGIS_VERSION 3.1.3+dfsg-1~exp1.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,7 +9,7 @@ RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d


### PR DESCRIPTION
 - `make update`
     -  Debian postgis update to 3.1.3
 -  resolving https://github.com/postgis/docker-postgis/actions/runs/1134340353 
     - `E: Version '3.1.2+dfsg-1~exp2.pgdg90+1' for 'postgresql-10-postgis-3' was not found`