### PR TITLE
PostgreSQL driver support

### DIFF
--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -48,6 +48,7 @@ RUN set -ex \
       libjson-c-dev \
       libmpfr-dev \
       libpcre3-dev \
+      libpq-dev \
       libprotobuf-c-dev \
       libsqlite3-dev \
       libtiff-dev \

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -48,6 +48,7 @@ RUN set -ex \
       libjson-c-dev \
       libmpfr-dev \
       libpcre3-dev \
+      libpq-dev \
       libprotobuf-c-dev \
       libsqlite3-dev \
       libtiff-dev \


### PR DESCRIPTION
PostgreSQL driver was missing from gdal tools:
```shell
$ ogr2ogr --formats
```

Adding `libpq-dev` fixes the problem.