### PR TITLE
Pgdev2

### DIFF
--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -48,6 +48,7 @@ RUN set -ex \
       libjson-c-dev \
       libmpfr-dev \
       libpcre3-dev \
+      libpq-dev \
       libprotobuf-c-dev \
       libsqlite3-dev \
       libtiff-dev \
@@ -61,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH e2ae3548344e7923d31ab42682e0f0e7f60c6a63
+#ENV SFCGAL_GIT_HASH 7d6bd802e7899a16b59277d6fb8204b55102c64d
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -81,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH b385f2142a1ab4007d5771c5570d8406873846de
+ENV PROJ_GIT_HASH c6c2a3b22ddef30a29cfc48ca810ee1a54385242
 
 RUN set -ex \
     && cd /usr/src \
@@ -97,8 +98,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-# Commits on Dec 16, 2021
-ENV GEOS_GIT_HASH d30798e5c0c9956b5e90e4960f0c445211ed8fe6
+ENV GEOS_GIT_HASH e1d8471e2a9f579ebfbf6f49b3e37bd6eaad8565
 
 RUN set -ex \
     && cd /usr/src \
@@ -115,7 +115,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 837be861fb2ac2ef3ee70bfd06309e039ef5c16f
+ENV GDAL_GIT_HASH 2618ede82419c09a2fd313d9cccfaf9f9acf93bc
 
 RUN set -ex \
     && cd /usr/src \
@@ -180,10 +180,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH e2ae3548344e7923d31ab42682e0f0e7f60c6a63
-ENV PROJ_GIT_HASH b385f2142a1ab4007d5771c5570d8406873846de
-ENV GEOS_GIT_HASH 1470d0a439b01a0d6ce601fb718177327a06fe14
-ENV GDAL_GIT_HASH 837be861fb2ac2ef3ee70bfd06309e039ef5c16f
+#ENV SFCGAL_GIT_HASH 7d6bd802e7899a16b59277d6fb8204b55102c64d
+ENV PROJ_GIT_HASH c6c2a3b22ddef30a29cfc48ca810ee1a54385242
+ENV GEOS_GIT_HASH e1d8471e2a9f579ebfbf6f49b3e37bd6eaad8565
+ENV GDAL_GIT_HASH 2618ede82419c09a2fd313d9cccfaf9f9acf93bc
 
 # Minimal command line test.
 RUN set -ex \
@@ -197,7 +197,7 @@ RUN set -ex \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH c9dfab57937b0e9454dbded9f4f7eaebbd79d0bd
+ENV POSTGIS_GIT_HASH b67f6c80f24edb57fa223a2065c2255bbb346cef
 
 RUN set -ex \
     && apt-get update \

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -48,6 +48,7 @@ RUN set -ex \
       libjson-c-dev \
       libmpfr-dev \
       libpcre3-dev \
+      libpq-dev \
       libprotobuf-c-dev \
       libsqlite3-dev \
       libtiff-dev \
@@ -61,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH e2ae3548344e7923d31ab42682e0f0e7f60c6a63
+#ENV SFCGAL_GIT_HASH 7d6bd802e7899a16b59277d6fb8204b55102c64d
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -81,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH b385f2142a1ab4007d5771c5570d8406873846de
+ENV PROJ_GIT_HASH c6c2a3b22ddef30a29cfc48ca810ee1a54385242
 
 RUN set -ex \
     && cd /usr/src \
@@ -97,8 +98,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-# Commits on Dec 16, 2021
-ENV GEOS_GIT_HASH d30798e5c0c9956b5e90e4960f0c445211ed8fe6
+ENV GEOS_GIT_HASH e1d8471e2a9f579ebfbf6f49b3e37bd6eaad8565
 
 RUN set -ex \
     && cd /usr/src \
@@ -115,7 +115,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 837be861fb2ac2ef3ee70bfd06309e039ef5c16f
+ENV GDAL_GIT_HASH 2618ede82419c09a2fd313d9cccfaf9f9acf93bc
 
 RUN set -ex \
     && cd /usr/src \
@@ -180,10 +180,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH e2ae3548344e7923d31ab42682e0f0e7f60c6a63
-ENV PROJ_GIT_HASH b385f2142a1ab4007d5771c5570d8406873846de
-ENV GEOS_GIT_HASH 1470d0a439b01a0d6ce601fb718177327a06fe14
-ENV GDAL_GIT_HASH 837be861fb2ac2ef3ee70bfd06309e039ef5c16f
+#ENV SFCGAL_GIT_HASH 7d6bd802e7899a16b59277d6fb8204b55102c64d
+ENV PROJ_GIT_HASH c6c2a3b22ddef30a29cfc48ca810ee1a54385242
+ENV GEOS_GIT_HASH e1d8471e2a9f579ebfbf6f49b3e37bd6eaad8565
+ENV GDAL_GIT_HASH 2618ede82419c09a2fd313d9cccfaf9f9acf93bc
 
 # Minimal command line test.
 RUN set -ex \
@@ -197,7 +197,7 @@ RUN set -ex \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH c9dfab57937b0e9454dbded9f4f7eaebbd79d0bd
+ENV POSTGIS_GIT_HASH b67f6c80f24edb57fa223a2065c2255bbb346cef
 
 RUN set -ex \
     && apt-get update \

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -195,6 +195,10 @@ RUN set -ex \
     && proj \
     && sfcgal-config --version
 
+# Testing ogr2ogr PostgreSQL driver.
+RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
+    || echo "ogr2ogr missing PostgreSQL driver" && exit 1
+
 # install postgis
 ENV POSTGIS_VERSION master
 ENV POSTGIS_GIT_HASH %%POSTGIS_GIT_HASH%%

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -48,6 +48,7 @@ RUN set -ex \
       libjson-c-dev \
       libmpfr-dev \
       libpcre3-dev \
+      libpq-dev \
       libprotobuf-c-dev \
       libsqlite3-dev \
       libtiff-dev \


### PR DESCRIPTION
Replaces #278 .

PostgreSQL driver was missing from gdal tools:
```shell
$ ogr2ogr --formats
```

Adding `libpq-dev` fixes the problem.