### PR TITLE
alpine upgrade to 3.15

### DIFF
--- a/10-2.5/alpine/Dockerfile
+++ b/10-2.5/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:10-alpine3.14
+FROM postgres:10-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 2.5.5
 ENV POSTGIS_SHA256 24b15ee36f3af02015da0e92a18f9046ea0b4fd24896196c8e6c2aa8e4b56baa
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/10-2.5/alpine/Dockerfile
+++ b/10-2.5/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/10-3.2/alpine/Dockerfile
+++ b/10-3.2/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:10-alpine3.14
+FROM postgres:10-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 3.2.0
 ENV POSTGIS_SHA256 c725d1be6d57ad199bbb6393cc3546defb70de1c78fe1787f7ccef2d51c3647b
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/10-3.2/alpine/Dockerfile
+++ b/10-3.2/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/11-2.5/alpine/Dockerfile
+++ b/11-2.5/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:11-alpine3.14
+FROM postgres:11-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 2.5.5
 ENV POSTGIS_SHA256 24b15ee36f3af02015da0e92a18f9046ea0b4fd24896196c8e6c2aa8e4b56baa
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/11-2.5/alpine/Dockerfile
+++ b/11-2.5/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/11-3.2/alpine/Dockerfile
+++ b/11-3.2/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:11-alpine3.14
+FROM postgres:11-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 3.2.0
 ENV POSTGIS_SHA256 c725d1be6d57ad199bbb6393cc3546defb70de1c78fe1787f7ccef2d51c3647b
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/11-3.2/alpine/Dockerfile
+++ b/11-3.2/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/12-3.2/alpine/Dockerfile
+++ b/12-3.2/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:12-alpine3.14
+FROM postgres:12-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 3.2.0
 ENV POSTGIS_SHA256 c725d1be6d57ad199bbb6393cc3546defb70de1c78fe1787f7ccef2d51c3647b
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/12-3.2/alpine/Dockerfile
+++ b/12-3.2/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/13-3.2/alpine/Dockerfile
+++ b/13-3.2/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:13-alpine3.14
+FROM postgres:13-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 3.2.0
 ENV POSTGIS_SHA256 c725d1be6d57ad199bbb6393cc3546defb70de1c78fe1787f7ccef2d51c3647b
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/13-3.2/alpine/Dockerfile
+++ b/13-3.2/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/14-3.2/alpine/Dockerfile
+++ b/14-3.2/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:14-alpine3.14
+FROM postgres:14-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 3.2.0
 ENV POSTGIS_SHA256 c725d1be6d57ad199bbb6393cc3546defb70de1c78fe1787f7ccef2d51c3647b
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/14-3.2/alpine/Dockerfile
+++ b/14-3.2/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/9.6-2.5/alpine/Dockerfile
+++ b/9.6-2.5/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:9.6-alpine3.14
+FROM postgres:9.6-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 2.5.5
 ENV POSTGIS_SHA256 24b15ee36f3af02015da0e92a18f9046ea0b4fd24896196c8e6c2aa8e4b56baa
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/9.6-2.5/alpine/Dockerfile
+++ b/9.6-2.5/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/9.6-3.2/alpine/Dockerfile
+++ b/9.6-3.2/alpine/Dockerfile
@@ -1,24 +1,47 @@
-FROM postgres:9.6-alpine3.14
+FROM postgres:9.6-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION 3.2.0
 ENV POSTGIS_SHA256 c725d1be6d57ad199bbb6393cc3546defb70de1c78fe1787f7ccef2d51c3647b
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/9.6-3.2/alpine/Dockerfile
+++ b/9.6-3.2/alpine/Dockerfile
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -1,24 +1,47 @@
-FROM postgres:%%PG_MAJOR%%-alpine3.14
+FROM postgres:%%PG_MAJOR%%-alpine3.15
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
 ENV POSTGIS_VERSION %%POSTGIS_VERSION%%
 ENV POSTGIS_SHA256 %%POSTGIS_SHA256%%
 
-#Temporary fix:
-#   for PostGIS 2.* - building a special geos
-#   reason:  PostGIS 2.5.5 is not working with GEOS 3.9.*
-ENV POSTGIS2_GEOS_VERSION tags/3.8.2
-
 RUN set -eux \
+    \
+    &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
+            export GEOS_ALPINE_VER=3.10 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
+            export GDAL_ALPINE_VER=3.4 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
+            export PROJ_ALPINE_VER=8.2 ; \
+        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
+            set -eux ; \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
+            export GEOS_ALPINE_VER=3.8 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
+            export GDAL_ALPINE_VER=3.2 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
+            export PROJ_ALPINE_VER=7.2 ; \
+            \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
+            \
+        else \
+            set -eux ; \
+            echo ".... unknown \$POSTGIS_VERSION ...." ; \
+            exit 1 ; \
+        fi \
     \
     && apk add --no-cache --virtual .fetch-deps \
         ca-certificates \
         openssl \
         tar \
     \
-    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/$POSTGIS_VERSION.tar.gz" \
-    && echo "$POSTGIS_SHA256 *postgis.tar.gz" | sha256sum -c - \
+    && wget -O postgis.tar.gz "https://github.com/postgis/postgis/archive/${POSTGIS_VERSION}.tar.gz" \
+    && echo "${POSTGIS_SHA256} *postgis.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/src/postgis \
     && tar \
         --extract \
@@ -28,44 +51,26 @@ RUN set -eux \
     && rm postgis.tar.gz \
     \
     && apk add --no-cache --virtual .build-deps \
+        \
+        gdal-dev~=${GDAL_ALPINE_VER} \
+        geos-dev~=${GEOS_ALPINE_VER} \
+        proj-dev~=${PROJ_ALPINE_VER} \
+        \
         autoconf \
         automake \
         clang-dev \
         file \
         g++ \
         gcc \
-        gdal-dev \
         gettext-dev \
         json-c-dev \
         libtool \
         libxml2-dev \
-        llvm11-dev \
+        llvm-dev \
         make \
         pcre-dev \
         perl \
-        proj-dev \
         protobuf-c-dev \
-     \
-# GEOS setup
-     && if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .build-deps-geos geos-dev cunit-dev ; \
-        elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
-            apk add --no-cache --virtual .build-deps-geos cmake git ; \
-            cd /usr/src ; \
-            git clone https://github.com/libgeos/geos.git ; \
-            cd geos ; \
-            git checkout ${POSTGIS2_GEOS_VERSION} -b geos_build ; \
-            mkdir cmake-build ; \
-            cd cmake-build ; \
-                cmake -DCMAKE_BUILD_TYPE=Release .. ; \
-                make -j$(nproc) ; \
-                make check ; \
-                make install ; \
-            cd / ; \
-            rm -fr /usr/src/geos ; \
-        else \
-            echo ".... unknown PosGIS ...." ; \
-        fi \
     \
 # build PostGIS
     \
@@ -86,25 +91,31 @@ RUN set -eux \
     && make -j$(nproc) check RUNTESTFLAGS=--extension   PGUSER=postgres \
     #&& make -j$(nproc) check RUNTESTFLAGS=--dumprestore PGUSER=postgres \
     #&& make garden                                      PGUSER=postgres \
+    \
+    && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
+    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
+    \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
     && rm -rf /tempdb \
     && rm -rf /tmp/pgis_reg \
 # add .postgis-rundeps
     && apk add --no-cache --virtual .postgis-rundeps \
-        gdal \
+        \
+        gdal~=${GDAL_ALPINE_VER} \
+        geos~=${GEOS_ALPINE_VER} \
+        proj~=${PROJ_ALPINE_VER} \
+        \
         json-c \
         libstdc++ \
         pcre \
-        proj \
         protobuf-c \
-     # Geos setup
-     && if [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
-            apk add --no-cache --virtual .postgis-rundeps-geos geos ; \
-        fi \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    && apk del .fetch-deps .build-deps .build-deps-geos
+    && apk del .fetch-deps .build-deps \
+# print PostGIS_Full_Version() for the log.
+    && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -9,24 +9,32 @@ RUN set -eux \
     \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
+            #
+            # using only v3.15
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.15 \
             export GEOS_ALPINE_VER=3.10 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.15 \
             export GDAL_ALPINE_VER=3.4 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.15 \
             export PROJ_ALPINE_VER=8.2 ; \
+            #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \
+            #
+            # using older branches v3.13; v3.14 for GEOS,GDAL,PROJ
+            #
             #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.13 \
             export GEOS_ALPINE_VER=3.8 ; \
             #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.14 \
             export GDAL_ALPINE_VER=3.2 ; \
             #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.14 \
             export PROJ_ALPINE_VER=7.2 ; \
+            #
             \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community' >> /etc/apk/repositories ; \
-            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main' >> /etc/apk/repositories ; \
+            echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/main'      >> /etc/apk/repositories ; \
             echo 'https://dl-cdn.alpinelinux.org/alpine/v3.13/community' >> /etc/apk/repositories ; \
             \
         else \
@@ -93,7 +101,7 @@ RUN set -eux \
     #&& make garden                                      PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
-    && su postgres -c 'psql -t -c "SELECT version();"' >> /_pgis_full_version.txt \
+    && su postgres -c 'psql -t -c "SELECT version();"'              >> /_pgis_full_version.txt \
     && su postgres -c 'psql -t -c "SELECT PostGIS_Full_Version();"' >> /_pgis_full_version.txt \
     \
     && su postgres -c 'pg_ctl -D /tempdb --mode=immediate stop' \
@@ -114,7 +122,7 @@ RUN set -eux \
     && cd / \
     && rm -rf /usr/src/postgis \
     && apk del .fetch-deps .build-deps \
-# print PostGIS_Full_Version() for the log.
+# print PostGIS_Full_Version() for the log. ( experimental & internal )
     && cat /_pgis_full_version.txt
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh


### PR DESCRIPTION
- upgrade to alpine 3.15 ( from alpine 3.14 )
- postgis 2.5 : revert geos build and using older package from alpine repo = v3.13
- postgis 2.5 : using older gdal, proj  from alpine repo = v3.14
- small refactoring
- added `_pgis_full_version.txt` debug file for alpine build. ( experimental )

IMHO: the size changes looks normal 
```
# 10-2.5-alpine
postgis/postgis                    10-2.5-alpine      b4b7d6ef936b   33 hours ago        201MB  <-- now: with alpine 3.14
pgis10_25_alpine_v3                latest             cb1fd046db9f   13 minutes ago      198MB  <-- NEW: with alpine 3.15 

# 10-3.2-alpine
postgis/postgis                    10-3.2-alpine      a803a0b7cae5   33 hours ago        208MB  <-- now: with alpine 3.14
pgis10_32_alpine_v3                latest             4306f4c1cb78   10 minutes ago      237MB  <-- NEW: with alpine 3.15  ; newer geos,gdal,proj
```

the expected new Alpine - postgis versions
* 3.2 `POSTGIS="3.2.0 0" [EXTENSION] PGSQL="100" GEOS="3.10.1-CAPI-1.16.0" PROJ="8.2.0" LIBXML="2.9.12" LIBJSON="0.15" LIBPROTOBUF="1.4.0" WAGYU="0.5.0 (Internal)"`
* 2.5 `POSTGIS="2.5.5" [EXTENSION] PGSQL="100" GEOS="3.8.1-CAPI-1.13.3" PROJ="Rel. 7.2.1, January 1st, 2021" GDAL="GDAL 3.2.3, released 2021/04/27" LIBXML="2.9.12" LIBJSON="0.15" LIBPROTOBUF="1.4.0" RASTER`