### PR TITLE
Postgis main branch removed; using github mirror; update (13|14)-master

### DIFF
--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH 7d6bd802e7899a16b59277d6fb8204b55102c64d
+#ENV SFCGAL_GIT_HASH cf03cf7869778f69f8baddfbd73415bf99499663
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH c6c2a3b22ddef30a29cfc48ca810ee1a54385242
+ENV PROJ_GIT_HASH 4ecb0abb8c3d3f5efcdd79643bc3302aa9bc6d1e
 
 RUN set -ex \
     && cd /usr/src \
@@ -98,7 +98,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH e1d8471e2a9f579ebfbf6f49b3e37bd6eaad8565
+ENV GEOS_GIT_HASH 70d2111bd66ea848809e5738896256199d9a7cba
 
 RUN set -ex \
     && cd /usr/src \
@@ -115,7 +115,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 2618ede82419c09a2fd313d9cccfaf9f9acf93bc
+ENV GDAL_GIT_HASH 642888ff9f9e1814f962d4cff5082257a47e84fd
 
 RUN set -ex \
     && cd /usr/src \
@@ -180,10 +180,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH 7d6bd802e7899a16b59277d6fb8204b55102c64d
-ENV PROJ_GIT_HASH c6c2a3b22ddef30a29cfc48ca810ee1a54385242
-ENV GEOS_GIT_HASH e1d8471e2a9f579ebfbf6f49b3e37bd6eaad8565
-ENV GDAL_GIT_HASH 2618ede82419c09a2fd313d9cccfaf9f9acf93bc
+#ENV SFCGAL_GIT_HASH cf03cf7869778f69f8baddfbd73415bf99499663
+ENV PROJ_GIT_HASH 4ecb0abb8c3d3f5efcdd79643bc3302aa9bc6d1e
+ENV GEOS_GIT_HASH 70d2111bd66ea848809e5738896256199d9a7cba
+ENV GDAL_GIT_HASH 642888ff9f9e1814f962d4cff5082257a47e84fd
 
 # Minimal command line test.
 RUN set -ex \
@@ -195,9 +195,13 @@ RUN set -ex \
     && proj \
     && sfcgal-config --version
 
+# Testing ogr2ogr PostgreSQL driver.
+RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
+    || echo "ogr2ogr missing PostgreSQL driver" && exit 1
+
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH b67f6c80f24edb57fa223a2065c2255bbb346cef
+ENV POSTGIS_GIT_HASH 4fa57df0b3bd726346e1fd272921a29ab888b55f
 
 RUN set -ex \
     && apt-get update \

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH 7d6bd802e7899a16b59277d6fb8204b55102c64d
+#ENV SFCGAL_GIT_HASH cf03cf7869778f69f8baddfbd73415bf99499663
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH c6c2a3b22ddef30a29cfc48ca810ee1a54385242
+ENV PROJ_GIT_HASH 4ecb0abb8c3d3f5efcdd79643bc3302aa9bc6d1e
 
 RUN set -ex \
     && cd /usr/src \
@@ -98,7 +98,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH e1d8471e2a9f579ebfbf6f49b3e37bd6eaad8565
+ENV GEOS_GIT_HASH 70d2111bd66ea848809e5738896256199d9a7cba
 
 RUN set -ex \
     && cd /usr/src \
@@ -115,7 +115,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 2618ede82419c09a2fd313d9cccfaf9f9acf93bc
+ENV GDAL_GIT_HASH 642888ff9f9e1814f962d4cff5082257a47e84fd
 
 RUN set -ex \
     && cd /usr/src \
@@ -180,10 +180,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH 7d6bd802e7899a16b59277d6fb8204b55102c64d
-ENV PROJ_GIT_HASH c6c2a3b22ddef30a29cfc48ca810ee1a54385242
-ENV GEOS_GIT_HASH e1d8471e2a9f579ebfbf6f49b3e37bd6eaad8565
-ENV GDAL_GIT_HASH 2618ede82419c09a2fd313d9cccfaf9f9acf93bc
+#ENV SFCGAL_GIT_HASH cf03cf7869778f69f8baddfbd73415bf99499663
+ENV PROJ_GIT_HASH 4ecb0abb8c3d3f5efcdd79643bc3302aa9bc6d1e
+ENV GEOS_GIT_HASH 70d2111bd66ea848809e5738896256199d9a7cba
+ENV GDAL_GIT_HASH 642888ff9f9e1814f962d4cff5082257a47e84fd
 
 # Minimal command line test.
 RUN set -ex \
@@ -195,9 +195,13 @@ RUN set -ex \
     && proj \
     && sfcgal-config --version
 
+# Testing ogr2ogr PostgreSQL driver.
+RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
+    || echo "ogr2ogr missing PostgreSQL driver" && exit 1
+
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH b67f6c80f24edb57fa223a2065c2255bbb346cef
+ENV POSTGIS_GIT_HASH 4fa57df0b3bd726346e1fd272921a29ab888b55f
 
 RUN set -ex \
     && apt-get update \

--- a/update.sh
+++ b/update.sh
@@ -36,7 +36,7 @@ sfcgalGitHash="$(git ls-remote https://gitlab.com/Oslandia/SFCGAL.git heads/mast
 projGitHash="$(git ls-remote https://github.com/OSGeo/PROJ.git heads/master | awk '{ print $1}')"
 gdalGitHash="$(git ls-remote https://github.com/OSGeo/gdal.git refs/heads/master | grep '\srefs/heads/master' | awk '{ print $1}')"
 geosGitHash="$(git ls-remote https://github.com/libgeos/geos.git heads/main | awk '{ print $1}')"
-postgisGitHash="$(git ls-remote https://git.osgeo.org/gitea/postgis/postgis.git heads/main | awk '{ print $1}')"
+postgisGitHash="$(git ls-remote https://github.com/postgis/postgis.git heads/master | awk '{ print $1}')"
 
 declare -A suitePackageList=() suiteArches=()
 for version in "${versions[@]}"; do


### PR DESCRIPTION
- Using github mirror insted of osgeo ( so now same as in the Dockerfile.master.template )
- Postgis "main" branch removed; using "master";  https://lists.osgeo.org/pipermail/postgis-devel/2022-January/029336.html
- `make update`   ( updating:  `13-master/Dockerfile` ; `14-master/Dockerfile`)