### PR TITLE
"fix search_path race" v2 - with make update

### DIFF
--- a/10-2.5/alpine/initdb-postgis.sh
+++ b/10-2.5/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/10-2.5/initdb-postgis.sh
+++ b/10-2.5/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/10-3.2/alpine/initdb-postgis.sh
+++ b/10-3.2/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/10-3.2/initdb-postgis.sh
+++ b/10-3.2/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/11-2.5/alpine/initdb-postgis.sh
+++ b/11-2.5/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/11-2.5/initdb-postgis.sh
+++ b/11-2.5/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/11-3.2/alpine/initdb-postgis.sh
+++ b/11-3.2/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/11-3.2/initdb-postgis.sh
+++ b/11-3.2/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/12-3.2/alpine/initdb-postgis.sh
+++ b/12-3.2/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/12-3.2/initdb-postgis.sh
+++ b/12-3.2/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/13-3.2/alpine/initdb-postgis.sh
+++ b/13-3.2/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/13-3.2/initdb-postgis.sh
+++ b/13-3.2/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH b547721ba083e98252101431e7df0015631784b0
+#ENV SFCGAL_GIT_HASH 54b78af7b42f0f348f34879616a5da480b8e4974
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 8c51e3c99acc9083d82a5a7a6dae146e2a689f8e
+ENV PROJ_GIT_HASH 98e5ef0bab8bde49b2bddb71694c3b0294387e64
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 804abffe76c4e3fbc32399b82835d6b97cda7714
+ENV GEOS_GIT_HASH 8a9326ebcad93bb0807347409bb97d16ee1d0ef0
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH aac77f0465551112e29b7c21201bbb5a4e3b4bc3
+ENV GDAL_GIT_HASH 98c9ecf8513325bb69888d368bd9a0d54b79e72b
 
 RUN set -ex \
     && cd /usr/src \
@@ -196,10 +196,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH b547721ba083e98252101431e7df0015631784b0
-ENV PROJ_GIT_HASH 8c51e3c99acc9083d82a5a7a6dae146e2a689f8e
-ENV GEOS_GIT_HASH 804abffe76c4e3fbc32399b82835d6b97cda7714
-ENV GDAL_GIT_HASH aac77f0465551112e29b7c21201bbb5a4e3b4bc3
+#ENV SFCGAL_GIT_HASH 54b78af7b42f0f348f34879616a5da480b8e4974
+ENV PROJ_GIT_HASH 98e5ef0bab8bde49b2bddb71694c3b0294387e64
+ENV GEOS_GIT_HASH 8a9326ebcad93bb0807347409bb97d16ee1d0ef0
+ENV GDAL_GIT_HASH 98c9ecf8513325bb69888d368bd9a0d54b79e72b
 
 # Minimal command line test.
 RUN set -ex \
@@ -217,7 +217,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 842dd8b50274bfec09ab7430a735764d85ce0a0d
+ENV POSTGIS_GIT_HASH c9885d5275dd022d19b0061df256cd0425bf20dd
 
 RUN set -ex \
     && apt-get update \

--- a/13-master/initdb-postgis.sh
+++ b/13-master/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/14-3.2/alpine/initdb-postgis.sh
+++ b/14-3.2/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/14-3.2/initdb-postgis.sh
+++ b/14-3.2/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH b547721ba083e98252101431e7df0015631784b0
+#ENV SFCGAL_GIT_HASH 54b78af7b42f0f348f34879616a5da480b8e4974
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 8c51e3c99acc9083d82a5a7a6dae146e2a689f8e
+ENV PROJ_GIT_HASH 98e5ef0bab8bde49b2bddb71694c3b0294387e64
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 804abffe76c4e3fbc32399b82835d6b97cda7714
+ENV GEOS_GIT_HASH 8a9326ebcad93bb0807347409bb97d16ee1d0ef0
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH aac77f0465551112e29b7c21201bbb5a4e3b4bc3
+ENV GDAL_GIT_HASH 98c9ecf8513325bb69888d368bd9a0d54b79e72b
 
 RUN set -ex \
     && cd /usr/src \
@@ -196,10 +196,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH b547721ba083e98252101431e7df0015631784b0
-ENV PROJ_GIT_HASH 8c51e3c99acc9083d82a5a7a6dae146e2a689f8e
-ENV GEOS_GIT_HASH 804abffe76c4e3fbc32399b82835d6b97cda7714
-ENV GDAL_GIT_HASH aac77f0465551112e29b7c21201bbb5a4e3b4bc3
+#ENV SFCGAL_GIT_HASH 54b78af7b42f0f348f34879616a5da480b8e4974
+ENV PROJ_GIT_HASH 98e5ef0bab8bde49b2bddb71694c3b0294387e64
+ENV GEOS_GIT_HASH 8a9326ebcad93bb0807347409bb97d16ee1d0ef0
+ENV GDAL_GIT_HASH 98c9ecf8513325bb69888d368bd9a0d54b79e72b
 
 # Minimal command line test.
 RUN set -ex \
@@ -217,7 +217,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 842dd8b50274bfec09ab7430a735764d85ce0a0d
+ENV POSTGIS_GIT_HASH c9885d5275dd022d19b0061df256cd0425bf20dd
 
 RUN set -ex \
     && apt-get update \

--- a/14-master/initdb-postgis.sh
+++ b/14-master/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/9.6-2.5/alpine/initdb-postgis.sh
+++ b/9.6-2.5/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/9.6-2.5/initdb-postgis.sh
+++ b/9.6-2.5/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/9.6-3.2/alpine/initdb-postgis.sh
+++ b/9.6-3.2/alpine/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/9.6-3.2/initdb-postgis.sh
+++ b/9.6-3.2/initdb-postgis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,6 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL


### PR DESCRIPTION
the https://github.com/postgis/docker-postgis/pull/290 only has been fixed the template files;
and this PR with `make update` - regenerating everywhere.

( cc: @strk ; @phillipross )

Locally tested:

the new `postgis/postgis:13-3.2-alpine` version: 

```
psql (13.6)
Type "help" for help.

postgres=# show search_path;
           search_path            
----------------------------------
 "$user", public, topology, tiger
(1 row)
```
the new `postgis/postgis:13-3.2` version: 

```
psql (13.6 (Debian 13.6-1.pgdg110+1))
Type "help" for help.

postgres=# show search_path;
           search_path            
----------------------------------
 "$user", public, topology, tiger
(1 row)
```

and the server logs look ok.
Alpine log
```log
waiting for server to start....2022-04-08 09:41:49.648 UTC [36] LOG:  starting PostgreSQL 13.6 on x86_64-pc-linux-musl, compiled by gcc (Alpine 10.3.1_git20211027) 10.3.1 20211027, 64-bit
2022-04-08 09:41:49.650 UTC [36] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2022-04-08 09:41:49.654 UTC [37] LOG:  database system was shut down at 2022-04-08 09:41:49 UTC
2022-04-08 09:41:49.657 UTC [36] LOG:  database system is ready to accept connections
 done
server started

/usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/10_postgis.sh
CREATE DATABASE
Loading PostGIS extensions into template_postgis
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
Loading PostGIS extensions into postgres
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION

waiting for server to shut down....2022-04-08 09:41:53.163 UTC [36] LOG:  received fast shutdown request
```

debian log - has an extra `You are now connected to database "postgres" as user "postgres".`

```
waiting for server to start....2022-04-08 10:47:55.803 UTC [49] LOG:  starting PostgreSQL 13.6 (Debian 13.6-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
2022-04-08 10:47:55.804 UTC [49] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2022-04-08 10:47:55.810 UTC [50] LOG:  database system was shut down at 2022-04-08 10:47:55 UTC
2022-04-08 10:47:55.815 UTC [49] LOG:  database system is ready to accept connections
 done
server started

/usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/10_postgis.sh
CREATE DATABASE
Loading PostGIS extensions into template_postgis
CREATE EXTENSION
CREATE EXTENSION
You are now connected to database "template_postgis" as user "postgres".
CREATE EXTENSION
CREATE EXTENSION
Loading PostGIS extensions into postgres
CREATE EXTENSION
CREATE EXTENSION
You are now connected to database "postgres" as user "postgres".
CREATE EXTENSION
CREATE EXTENSION

waiting for server to shut down...2022-04-08 10:47:58.581 UTC [49] LOG:  received fast shutdown request
```
