### PR TITLE
Fix search_path race by separating commands way

### DIFF
--- a/10-2.5/alpine/initdb-postgis.sh
+++ b/10-2.5/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/10-2.5/initdb-postgis.sh
+++ b/10-2.5/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/10-3.2/alpine/initdb-postgis.sh
+++ b/10-3.2/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/10-3.2/initdb-postgis.sh
+++ b/10-3.2/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/11-2.5/alpine/initdb-postgis.sh
+++ b/11-2.5/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/11-2.5/initdb-postgis.sh
+++ b/11-2.5/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/11-3.2/alpine/initdb-postgis.sh
+++ b/11-3.2/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/11-3.2/initdb-postgis.sh
+++ b/11-3.2/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/12-3.2/alpine/initdb-postgis.sh
+++ b/12-3.2/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/12-3.2/initdb-postgis.sh
+++ b/12-3.2/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/13-3.2/alpine/initdb-postgis.sh
+++ b/13-3.2/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/13-3.2/initdb-postgis.sh
+++ b/13-3.2/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 9f89c7288e44c64ba234a299b1d5528a54d9d61e
+ENV PROJ_GIT_HASH c1083644bcf12b3ce360090613f86c7a8520987f
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 2a82afc1ac2327966f56bdf35a6d88aaadb81330
+ENV GEOS_GIT_HASH c8bba596e9cdcf8ad55d804bfa9ba6e4394722a1
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH e1f2b40558cb61dc9ecd3de3282da7115c129c4f
+ENV GDAL_GIT_HASH 437570ac3e3a3d9a5d65959bebe72f7e7e12ec99
 
 RUN set -ex \
     && cd /usr/src \
@@ -197,9 +197,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 #ENV SFCGAL_GIT_HASH 54b78af7b42f0f348f34879616a5da480b8e4974
-ENV PROJ_GIT_HASH 9f89c7288e44c64ba234a299b1d5528a54d9d61e
-ENV GEOS_GIT_HASH 2a82afc1ac2327966f56bdf35a6d88aaadb81330
-ENV GDAL_GIT_HASH e1f2b40558cb61dc9ecd3de3282da7115c129c4f
+ENV PROJ_GIT_HASH c1083644bcf12b3ce360090613f86c7a8520987f
+ENV GEOS_GIT_HASH c8bba596e9cdcf8ad55d804bfa9ba6e4394722a1
+ENV GDAL_GIT_HASH 437570ac3e3a3d9a5d65959bebe72f7e7e12ec99
 
 # Minimal command line test.
 RUN set -ex \
@@ -217,7 +217,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 6febe57e76d2239ea9779c489eff376f3ed76e72
+ENV POSTGIS_GIT_HASH 50f0801edf94b9f99af34bc9fcdd4826ca9ee994
 
 RUN set -ex \
     && apt-get update \

--- a/13-master/initdb-postgis.sh
+++ b/13-master/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/14-3.2/alpine/initdb-postgis.sh
+++ b/14-3.2/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/14-3.2/initdb-postgis.sh
+++ b/14-3.2/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 9f89c7288e44c64ba234a299b1d5528a54d9d61e
+ENV PROJ_GIT_HASH c1083644bcf12b3ce360090613f86c7a8520987f
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 2a82afc1ac2327966f56bdf35a6d88aaadb81330
+ENV GEOS_GIT_HASH c8bba596e9cdcf8ad55d804bfa9ba6e4394722a1
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH e1f2b40558cb61dc9ecd3de3282da7115c129c4f
+ENV GDAL_GIT_HASH 437570ac3e3a3d9a5d65959bebe72f7e7e12ec99
 
 RUN set -ex \
     && cd /usr/src \
@@ -197,9 +197,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 #ENV SFCGAL_GIT_HASH 54b78af7b42f0f348f34879616a5da480b8e4974
-ENV PROJ_GIT_HASH 9f89c7288e44c64ba234a299b1d5528a54d9d61e
-ENV GEOS_GIT_HASH 2a82afc1ac2327966f56bdf35a6d88aaadb81330
-ENV GDAL_GIT_HASH e1f2b40558cb61dc9ecd3de3282da7115c129c4f
+ENV PROJ_GIT_HASH c1083644bcf12b3ce360090613f86c7a8520987f
+ENV GEOS_GIT_HASH c8bba596e9cdcf8ad55d804bfa9ba6e4394722a1
+ENV GDAL_GIT_HASH 437570ac3e3a3d9a5d65959bebe72f7e7e12ec99
 
 # Minimal command line test.
 RUN set -ex \
@@ -217,7 +217,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 6febe57e76d2239ea9779c489eff376f3ed76e72
+ENV POSTGIS_GIT_HASH 50f0801edf94b9f99af34bc9fcdd4826ca9ee994
 
 RUN set -ex \
     && apt-get update \

--- a/14-master/initdb-postgis.sh
+++ b/14-master/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/9.6-2.5/alpine/initdb-postgis.sh
+++ b/9.6-2.5/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/9.6-2.5/initdb-postgis.sh
+++ b/9.6-2.5/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/9.6-3.2/alpine/initdb-postgis.sh
+++ b/9.6-3.2/alpine/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/9.6-3.2/initdb-postgis.sh
+++ b/9.6-3.2/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/initdb-postgis.sh
+++ b/initdb-postgis.sh
@@ -16,9 +16,9 @@ for DB in template_postgis "$POSTGRES_DB"; do
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
+EOSQL
+
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL


### PR DESCRIPTION
Closes #296

@ImreSamu (CC: @strk)
I create this PR with the following steps, so could you check this ?

Note that my environment is macOS Monterey M1 (Apple Silicon) with zsh, so I couldn't execute `make test` due to No.3 error.

1. Apply #266 description's following diff.
   > The following diff is my suggestion, but I am not sure whether the sessions are separated and original #290 issue will be solved by this.
   ```diff
   --- a/initdb-postgis.sh
   +++ b/initdb-postgis.sh
           "${psql[@]}" --dbname="$DB" <<-'EOSQL'
                   CREATE EXTENSION IF NOT EXISTS postgis;
                   CREATE EXTENSION IF NOT EXISTS postgis_topology;
   -               -- Reconnect to update pg_setting.resetval
   -               -- See https://github.com/postgis/docker-postgis/issues/288
   -               \c
   +EOSQL
   +
   +       "${psql[@]}" --dbname="$DB" <<-'EOSQL'
                   CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
                   CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
    EOSQL
   ```
2. Execute `make update` to apply above changes to all.
3. Execute `make test` with setting environment variables, but encounter the following bash error.
   ```zsh
   % export VERSION=14-3.2
   % export VARIANT=default
   % make test
   docker build --pull -t postgis/postgis:14-3.2 14-3.2
   :
   testing postgis/postgis:14-3.2
	'utc' [1/3]...passed
	'no-hard-coded-passwords' [2/3].../Users/sanak/official-images/test/tests/no-hard-coded-passwords/run.sh: line 12: declare: -A: invalid option
   declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
   failed
   :
   ```
4. Build image from command line.
   ```zsh
   % docker build --pull --no-cache -t postgis/postgis:14-3.2 14-3.2
   ```
5. Check whether search_path is still valid.
   ```zsh
   % docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis:14-3.2
   % docker exec -ti some-postgis psql -U postgres
   psql (14.3 (Debian 14.3-1.pgdg110+1))
   Type "help" for help.
   
   postgres=# show search_path;
              search_path            
   ----------------------------------
    "$user", public, topology, tiger
   (1 row)
   ```
6. Check whether reconnecting is not happen. (Comparing with https://github.com/postgis/docker-postgis/pull/292#issue-1197169442 - debian log)
   ```zsh
   /usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/10_postgis.sh
   CREATE DATABASE
   Loading PostGIS extensions into template_postgis
   CREATE EXTENSION
   CREATE EXTENSION
   CREATE EXTENSION
   CREATE EXTENSION
   Loading PostGIS extensions into postgres
   CREATE EXTENSION
   CREATE EXTENSION
   CREATE EXTENSION
   CREATE EXTENSION
   
   waiting for server to shut down....2022-06-06 09:33:26.107 UTC [48] LOG:  received fast shutdown request
   ```