### PR TITLE
fixing Dockerhub link(s) to the Dockerfile(s)

### DIFF
--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 5b2d59b68f931303d73e742763309d258f9335d4
+ENV PROJ_GIT_HASH 2d8cf765765ac0499d2b4cccabfce55c33c9bafb
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 158f473911c30d04f9694fb2e46cc3d38cd3b3f3
+ENV GDAL_GIT_HASH 0b1e20dd2d31d656330aeec983f1e8f433332f77
 
 RUN set -ex \
     && cd /usr/src \
@@ -197,9 +197,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 #ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
-ENV PROJ_GIT_HASH 5b2d59b68f931303d73e742763309d258f9335d4
+ENV PROJ_GIT_HASH 2d8cf765765ac0499d2b4cccabfce55c33c9bafb
 ENV GEOS_GIT_HASH e3abcc8fc0f60035c7d8bda65e2417873f6da872
-ENV GDAL_GIT_HASH 158f473911c30d04f9694fb2e46cc3d38cd3b3f3
+ENV GDAL_GIT_HASH 0b1e20dd2d31d656330aeec983f1e8f433332f77
 
 # Minimal command line test.
 RUN set -ex \
@@ -217,7 +217,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 5cc346ae8019da12ccd6162a3b9022a9600a3167
+ENV POSTGIS_GIT_HASH a31a43a7a74ad8f5c22b165c3c92bfd2f9ad92f7
 
 RUN set -ex \
     && apt-get update \

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 5b2d59b68f931303d73e742763309d258f9335d4
+ENV PROJ_GIT_HASH 2d8cf765765ac0499d2b4cccabfce55c33c9bafb
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 158f473911c30d04f9694fb2e46cc3d38cd3b3f3
+ENV GDAL_GIT_HASH 0b1e20dd2d31d656330aeec983f1e8f433332f77
 
 RUN set -ex \
     && cd /usr/src \
@@ -197,9 +197,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 #ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
-ENV PROJ_GIT_HASH 5b2d59b68f931303d73e742763309d258f9335d4
+ENV PROJ_GIT_HASH 2d8cf765765ac0499d2b4cccabfce55c33c9bafb
 ENV GEOS_GIT_HASH e3abcc8fc0f60035c7d8bda65e2417873f6da872
-ENV GDAL_GIT_HASH 158f473911c30d04f9694fb2e46cc3d38cd3b3f3
+ENV GDAL_GIT_HASH 0b1e20dd2d31d656330aeec983f1e8f433332f77
 
 # Minimal command line test.
 RUN set -ex \
@@ -217,7 +217,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 5cc346ae8019da12ccd6162a3b9022a9600a3167
+ENV POSTGIS_GIT_HASH a31a43a7a74ad8f5c22b165c3c92bfd2f9ad92f7
 
 RUN set -ex \
     && apt-get update \

--- a/15beta2-master/Dockerfile
+++ b/15beta2-master/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 5b2d59b68f931303d73e742763309d258f9335d4
+ENV PROJ_GIT_HASH 2d8cf765765ac0499d2b4cccabfce55c33c9bafb
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 158f473911c30d04f9694fb2e46cc3d38cd3b3f3
+ENV GDAL_GIT_HASH 0b1e20dd2d31d656330aeec983f1e8f433332f77
 
 RUN set -ex \
     && cd /usr/src \
@@ -197,9 +197,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 #ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
-ENV PROJ_GIT_HASH 5b2d59b68f931303d73e742763309d258f9335d4
+ENV PROJ_GIT_HASH 2d8cf765765ac0499d2b4cccabfce55c33c9bafb
 ENV GEOS_GIT_HASH e3abcc8fc0f60035c7d8bda65e2417873f6da872
-ENV GDAL_GIT_HASH 158f473911c30d04f9694fb2e46cc3d38cd3b3f3
+ENV GDAL_GIT_HASH 0b1e20dd2d31d656330aeec983f1e8f433332f77
 
 # Minimal command line test.
 RUN set -ex \
@@ -217,7 +217,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 5cc346ae8019da12ccd6162a3b9022a9600a3167
+ENV POSTGIS_GIT_HASH a31a43a7a74ad8f5c22b165c3c92bfd2f9ad92f7
 
 RUN set -ex \
     && apt-get update \

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Recomended version for the new users: `postgis/postgis:14-3.2`
 
 | DockerHub image | Dockerfile | OS | Postgres | PostGIS |
 | --------------- | ---------- | -- | -------- | ------- |
-| [postgis/postgis:10-2.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=10-2.5) | [Dockerfile](./10-2.5/Dockerfile) | debian:stretch | 10 | 2.5.5 |
-| [postgis/postgis:10-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=10-3.2) | [Dockerfile](./10-3.2/Dockerfile) | debian:bullseye | 10 | 3.2.1 |
-| [postgis/postgis:11-2.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-2.5) | [Dockerfile](./11-2.5/Dockerfile) | debian:stretch | 11 | 2.5.5 |
-| [postgis/postgis:11-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-3.2) | [Dockerfile](./11-3.2/Dockerfile) | debian:bullseye | 11 | 3.2.1 |
-| [postgis/postgis:12-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.2) | [Dockerfile](./12-3.2/Dockerfile) | debian:bullseye | 12 | 3.2.1 |
-| [postgis/postgis:13-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.2) | [Dockerfile](./13-3.2/Dockerfile) | debian:bullseye | 13 | 3.2.1 |
-| [postgis/postgis:14-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.2) | [Dockerfile](./14-3.2/Dockerfile) | debian:bullseye | 14 | 3.2.1 |
+| [postgis/postgis:10-2.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=10-2.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/10-2.5/Dockerfile) | debian:stretch | 10 | 2.5.5 |
+| [postgis/postgis:10-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=10-3.2) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/10-3.2/Dockerfile) | debian:bullseye | 10 | 3.2.1 |
+| [postgis/postgis:11-2.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-2.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/11-2.5/Dockerfile) | debian:stretch | 11 | 2.5.5 |
+| [postgis/postgis:11-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-3.2) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/11-3.2/Dockerfile) | debian:bullseye | 11 | 3.2.1 |
+| [postgis/postgis:12-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.2) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.2/Dockerfile) | debian:bullseye | 12 | 3.2.1 |
+| [postgis/postgis:13-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.2) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.2/Dockerfile) | debian:bullseye | 13 | 3.2.1 |
+| [postgis/postgis:14-3.2](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.2) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.2/Dockerfile) | debian:bullseye | 14 | 3.2.1 |
 
 ### Alpine based
 
@@ -49,13 +49,13 @@ Recomended version for the new users: `postgis/postgis:14-3.2`
 
 | DockerHub image | Dockerfile | OS | Postgres | PostGIS |
 | --------------- | ---------- | -- | -------- | ------- |
-| [postgis/postgis:10-2.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=10-2.5-alpine) | [Dockerfile](./10-2.5/alpine/Dockerfile) | alpine:3.16 | 10 | 2.5.5 |
-| [postgis/postgis:10-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=10-3.2-alpine) | [Dockerfile](./10-3.2/alpine/Dockerfile) | alpine:3.16 | 10 | 3.2.1 |
-| [postgis/postgis:11-2.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-2.5-alpine) | [Dockerfile](./11-2.5/alpine/Dockerfile) | alpine:3.16 | 11 | 2.5.5 |
-| [postgis/postgis:11-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-3.2-alpine) | [Dockerfile](./11-3.2/alpine/Dockerfile) | alpine:3.16 | 11 | 3.2.1 |
-| [postgis/postgis:12-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.2-alpine) | [Dockerfile](./12-3.2/alpine/Dockerfile) | alpine:3.16 | 12 | 3.2.1 |
-| [postgis/postgis:13-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.2-alpine) | [Dockerfile](./13-3.2/alpine/Dockerfile) | alpine:3.16 | 13 | 3.2.1 |
-| [postgis/postgis:14-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.2-alpine) | [Dockerfile](./14-3.2/alpine/Dockerfile) | alpine:3.16 | 14 | 3.2.1 |
+| [postgis/postgis:10-2.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=10-2.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/10-2.5/alpine/Dockerfile) | alpine:3.16 | 10 | 2.5.5 |
+| [postgis/postgis:10-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=10-3.2-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/10-3.2/alpine/Dockerfile) | alpine:3.16 | 10 | 3.2.1 |
+| [postgis/postgis:11-2.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-2.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/11-2.5/alpine/Dockerfile) | alpine:3.16 | 11 | 2.5.5 |
+| [postgis/postgis:11-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-3.2-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/11-3.2/alpine/Dockerfile) | alpine:3.16 | 11 | 3.2.1 |
+| [postgis/postgis:12-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.2-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.2/alpine/Dockerfile) | alpine:3.16 | 12 | 3.2.1 |
+| [postgis/postgis:13-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.2-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.2/alpine/Dockerfile) | alpine:3.16 | 13 | 3.2.1 |
+| [postgis/postgis:14-3.2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.2-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.2/alpine/Dockerfile) | alpine:3.16 | 14 | 3.2.1 |
 
 ### Test images
 
@@ -64,11 +64,11 @@ Recomended version for the new users: `postgis/postgis:14-3.2`
 
 | DockerHub image | Dockerfile | OS | Postgres | PostGIS |
 | --------------- | ---------- | -- | -------- | ------- |
-| [postgis/postgis:13-master](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-master) | [Dockerfile](./13-master/Dockerfile) | debian:bullseye | 13 | development: postgis, geos, proj, gdal |
-| [postgis/postgis:14-3.3.0beta2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.3.0beta2-alpine) | [Dockerfile](./14-3.3.0beta2/alpine/Dockerfile) | alpine:3.16 | 14 | 3.3.0beta2 |
-| [postgis/postgis:14-master](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-master) | [Dockerfile](./14-master/Dockerfile) | debian:bullseye | 14 | development: postgis, geos, proj, gdal |
-| [postgis/postgis:15beta2-3.3.0beta2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15beta2-3.3.0beta2-alpine) | [Dockerfile](./15beta2-3.3.0beta2/alpine/Dockerfile) | alpine:3.16 | 15beta2 | 3.3.0beta2 |
-| [postgis/postgis:15beta2-master](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15beta2-master) | [Dockerfile](./15beta2-master/Dockerfile) | debian:bullseye | 15beta2 | development: postgis, geos, proj, gdal |
+| [postgis/postgis:13-master](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-master) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-master/Dockerfile) | debian:bullseye | 13 | development: postgis, geos, proj, gdal |
+| [postgis/postgis:14-3.3.0beta2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.3.0beta2-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.3.0beta2/alpine/Dockerfile) | alpine:3.16 | 14 | 3.3.0beta2 |
+| [postgis/postgis:14-master](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-master) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-master/Dockerfile) | debian:bullseye | 14 | development: postgis, geos, proj, gdal |
+| [postgis/postgis:15beta2-3.3.0beta2-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15beta2-3.3.0beta2-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15beta2-3.3.0beta2/alpine/Dockerfile) | alpine:3.16 | 15beta2 | 3.3.0beta2 |
+| [postgis/postgis:15beta2-master](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15beta2-master) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15beta2-master/Dockerfile) | debian:bullseye | 15beta2 | development: postgis, geos, proj, gdal |
 
 ## Usage
 

--- a/update.sh
+++ b/update.sh
@@ -13,11 +13,12 @@ versions=( "${versions[@]%/Dockerfile}" )
 for optimized in debian alpine test; do
     rm -f      _dockerlists_${optimized}.md
     echo " " > _dockerlists_${optimized}.md
-    echo "| DockerHub image | Dockerfile | OS | Postgres | PostGIS | " >> _dockerlists_${optimized}.md
-    echo "| --------------- | ---------- | -- | -------- | ------- | " >> _dockerlists_${optimized}.md
+    echo "| DockerHub image | Dockerfile | OS | Postgres | PostGIS |" >> _dockerlists_${optimized}.md
+    echo "| --------------- | ---------- | -- | -------- | ------- |" >> _dockerlists_${optimized}.md
 done
 
 dockerhublink="https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name="
+githubrepolink="https://github.com/postgis/docker-postgis/blob/master"
 
 # sort version numbers with highest last (so it goes first in .travis.yml)
 IFS=$'\n'; versions=( $(echo "${versions[*]}" | sort -V) ); unset IFS
@@ -152,7 +153,7 @@ for version in "${versions[@]}"; do
             fi
             sed -i 's/%%PG_MAJOR%%/'$postgresVersion'/g; s/%%POSTGIS_MAJOR%%/'$postgisMajor'/g; s/%%POSTGIS_VERSION%%/'$postgisFullVersion'/g; s/%%POSTGIS_GIT_HASH%%/'$postgisGitHash'/g; s/%%SFCGAL_GIT_HASH%%/'$sfcgalGitHash'/g; s/%%PROJ_GIT_HASH%%/'$projGitHash'/g; s/%%GDAL_GIT_HASH%%/'$gdalGitHash'/g; s/%%GEOS_GIT_HASH%%/'$geosGitHash'/g; s/%%BOOST_VERSION%%/'"$boostVersion"'/g; s/%%DEBIAN_VERSION%%/'"$suite"'/g;' "$version/Dockerfile"
 
-            echo "| [postgis/postgis:${version}](${dockerhublink}${version}) | [Dockerfile](./$version/Dockerfile) | debian:${suite} | ${postgresVersion} | ${postgisDocSrc} | " >> _dockerlists_${optimized}.md
+            echo "| [postgis/postgis:${version}](${dockerhublink}${version}) | [Dockerfile](${githubrepolink}/${version}/Dockerfile) | debian:${suite} | ${postgresVersion} | ${postgisDocSrc} |" >> _dockerlists_${optimized}.md
         )
     fi
 
@@ -176,7 +177,7 @@ for version in "${versions[@]}"; do
             mv "$version/$variant/Dockerfile.alpine.template" "$version/$variant/Dockerfile"
             sed -i 's/%%PG_MAJOR%%/'"$postgresVersion"'/g; s/%%POSTGIS_VERSION%%/'"$srcVersion"'/g; s/%%POSTGIS_SHA256%%/'"$srcSha256"'/g' "$version/$variant/Dockerfile"
 
-            echo "| [postgis/postgis:${version}-${variant}](${dockerhublink}${version}-${variant}) | [Dockerfile](./$version/$variant/Dockerfile) | alpine:3.16 | ${postgresVersion} | ${postgisDocSrc} | " >> _dockerlists_${optimized}.md
+            echo "| [postgis/postgis:${version}-${variant}](${dockerhublink}${version}-${variant}) | [Dockerfile](${githubrepolink}/${version}/${variant}/Dockerfile) | alpine:3.16 | ${postgresVersion} | ${postgisDocSrc} |" >> _dockerlists_${optimized}.md
         )
     done
 done


### PR DESCRIPTION
fixing https://registry.hub.docker.com/r/postgis/postgis/ (README) - Dockerfile links
  *  with adding the full path
     * now: `[Dockerfile](./14-3.2/Dockerfile) `
         *  and redirecting to the not exists  https://registry.hub.docker.com/r/postgis/postgis/14-3.2/Dockerfile  
     * proposed: `[Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.2/Dockerfile) `

imho: hardcoding the "master" branch is not a perfect solution, but it's the best I can come up with.
( and no problem if not accepted )

And the usual `make update` -  updating *-master Dockerfile(s) 

if the CI/CD ok:  ready to review/merge/reject