### PR TITLE
add ca-certificates: for accessing remote raster files;

### DIFF
--- a/10-2.5/Dockerfile
+++ b/10-2.5/Dockerfile
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION 2.5.5+dfsg-1.pgdg90+2
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*

--- a/10-2.5/alpine/Dockerfile
+++ b/10-2.5/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/10-3.2/Dockerfile
+++ b/10-3.2/Dockerfile
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION 3.2.3+dfsg-1.pgdg110+1
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*

--- a/10-3.2/alpine/Dockerfile
+++ b/10-3.2/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/11-2.5/Dockerfile
+++ b/11-2.5/Dockerfile
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION 2.5.5+dfsg-1.pgdg90+2
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*

--- a/11-2.5/alpine/Dockerfile
+++ b/11-2.5/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/11-3.2/Dockerfile
+++ b/11-3.2/Dockerfile
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION 3.2.3+dfsg-1.pgdg110+1
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*

--- a/11-3.2/alpine/Dockerfile
+++ b/11-3.2/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/12-3.2/Dockerfile
+++ b/12-3.2/Dockerfile
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION 3.2.3+dfsg-1.pgdg110+1
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*

--- a/12-3.2/alpine/Dockerfile
+++ b/12-3.2/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/13-3.2/Dockerfile
+++ b/13-3.2/Dockerfile
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION 3.2.3+dfsg-1.pgdg110+1
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*

--- a/13-3.2/alpine/Dockerfile
+++ b/13-3.2/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
+ENV GDAL_GIT_HASH 0592a219d11e8da539f1bc0cc9c4ce8865a08818
 
 RUN set -ex \
     && cd /usr/src \
@@ -212,7 +212,7 @@ COPY --from=builder /usr/local /usr/local
 #ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
 ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
 ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
-ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
+ENV GDAL_GIT_HASH 0592a219d11e8da539f1bc0cc9c4ce8865a08818
 
 # Minimal command line test.
 RUN set -ex \
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 2428842e84fc6b6ce8a15fcfe9a17d888cd0eaa5
+ENV POSTGIS_GIT_HASH 22708b56de39cb6d2c53278e6a2262e487119b2f
 
 RUN set -ex \
     && apt-get update \
@@ -294,11 +294,6 @@ RUN set -ex \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    \
-    #
-    # We keep ca-certificates: for accessing remote raster files
-    #    https://github.com/postgis/docker-postgis/issues/307
-    #
     && apt-get purge -y --autoremove \
       autoconf \
       automake \
@@ -331,5 +326,11 @@ RUN set -ex \
 RUN mkdir -p /docker-entrypoint-initdb.d
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin
-RUN cat /_pgis_full_version.txt
 
+RUN set -ex \
+    # Is the "ca-certificates" package installed? (for accessing remote raster files)
+    #   https://github.com/postgis/docker-postgis/issues/307
+    dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
+    \
+    # list postgresql, postgis version
+    && cat /_pgis_full_version.txt

--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
+#ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 1384b90602a6d2d51ed5ca0d2e28c8b4ada47aea
+ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 848bce44d308a05d082766da21ea5d9db2e79b8e
+ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 581246a1ccaf62438e20be371f82453c19d54394
+ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
 
 RUN set -ex \
     && cd /usr/src \
@@ -209,10 +209,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
-ENV PROJ_GIT_HASH 1384b90602a6d2d51ed5ca0d2e28c8b4ada47aea
-ENV GEOS_GIT_HASH 848bce44d308a05d082766da21ea5d9db2e79b8e
-ENV GDAL_GIT_HASH 581246a1ccaf62438e20be371f82453c19d54394
+#ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
+ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
+ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
+ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
 
 # Minimal command line test.
 RUN set -ex \
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 2fca9d65ced41fe2cbe36d0f9d05d109b39d70db
+ENV POSTGIS_GIT_HASH 2428842e84fc6b6ce8a15fcfe9a17d888cd0eaa5
 
 RUN set -ex \
     && apt-get update \
@@ -294,13 +294,17 @@ RUN set -ex \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
+    \
+    #
+    # We keep ca-certificates: for accessing remote raster files
+    #    https://github.com/postgis/docker-postgis/issues/307
+    #
     && apt-get purge -y --autoremove \
       autoconf \
       automake \
       autotools-dev \
       bison \
       build-essential \
-      ca-certificates \
       cmake \
       g++ \
       git \

--- a/13-master/Dockerfile
+++ b/13-master/Dockerfile
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 22708b56de39cb6d2c53278e6a2262e487119b2f
+ENV POSTGIS_GIT_HASH d31888c038285d36b460e34773e5dddece27d585
 
 RUN set -ex \
     && apt-get update \
@@ -330,7 +330,7 @@ COPY ./update-postgis.sh /usr/local/bin
 RUN set -ex \
     # Is the "ca-certificates" package installed? (for accessing remote raster files)
     #   https://github.com/postgis/docker-postgis/issues/307
-    dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
+    && dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
     \
     # list postgresql, postgis version
     && cat /_pgis_full_version.txt

--- a/14-3.2/Dockerfile
+++ b/14-3.2/Dockerfile
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION 3.2.3+dfsg-1.pgdg110+1
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*

--- a/14-3.2/alpine/Dockerfile
+++ b/14-3.2/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/14-3.3.0rc2/alpine/Dockerfile
+++ b/14-3.3.0rc2/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
+ENV GDAL_GIT_HASH 0592a219d11e8da539f1bc0cc9c4ce8865a08818
 
 RUN set -ex \
     && cd /usr/src \
@@ -212,7 +212,7 @@ COPY --from=builder /usr/local /usr/local
 #ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
 ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
 ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
-ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
+ENV GDAL_GIT_HASH 0592a219d11e8da539f1bc0cc9c4ce8865a08818
 
 # Minimal command line test.
 RUN set -ex \
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 2428842e84fc6b6ce8a15fcfe9a17d888cd0eaa5
+ENV POSTGIS_GIT_HASH 22708b56de39cb6d2c53278e6a2262e487119b2f
 
 RUN set -ex \
     && apt-get update \
@@ -294,11 +294,6 @@ RUN set -ex \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    \
-    #
-    # We keep ca-certificates: for accessing remote raster files
-    #    https://github.com/postgis/docker-postgis/issues/307
-    #
     && apt-get purge -y --autoremove \
       autoconf \
       automake \
@@ -331,5 +326,11 @@ RUN set -ex \
 RUN mkdir -p /docker-entrypoint-initdb.d
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin
-RUN cat /_pgis_full_version.txt
 
+RUN set -ex \
+    # Is the "ca-certificates" package installed? (for accessing remote raster files)
+    #   https://github.com/postgis/docker-postgis/issues/307
+    dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
+    \
+    # list postgresql, postgis version
+    && cat /_pgis_full_version.txt

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
+#ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 1384b90602a6d2d51ed5ca0d2e28c8b4ada47aea
+ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 848bce44d308a05d082766da21ea5d9db2e79b8e
+ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 581246a1ccaf62438e20be371f82453c19d54394
+ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
 
 RUN set -ex \
     && cd /usr/src \
@@ -209,10 +209,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
-ENV PROJ_GIT_HASH 1384b90602a6d2d51ed5ca0d2e28c8b4ada47aea
-ENV GEOS_GIT_HASH 848bce44d308a05d082766da21ea5d9db2e79b8e
-ENV GDAL_GIT_HASH 581246a1ccaf62438e20be371f82453c19d54394
+#ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
+ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
+ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
+ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
 
 # Minimal command line test.
 RUN set -ex \
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 2fca9d65ced41fe2cbe36d0f9d05d109b39d70db
+ENV POSTGIS_GIT_HASH 2428842e84fc6b6ce8a15fcfe9a17d888cd0eaa5
 
 RUN set -ex \
     && apt-get update \
@@ -294,13 +294,17 @@ RUN set -ex \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
+    \
+    #
+    # We keep ca-certificates: for accessing remote raster files
+    #    https://github.com/postgis/docker-postgis/issues/307
+    #
     && apt-get purge -y --autoremove \
       autoconf \
       automake \
       autotools-dev \
       bison \
       build-essential \
-      ca-certificates \
       cmake \
       g++ \
       git \

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 22708b56de39cb6d2c53278e6a2262e487119b2f
+ENV POSTGIS_GIT_HASH d31888c038285d36b460e34773e5dddece27d585
 
 RUN set -ex \
     && apt-get update \
@@ -330,7 +330,7 @@ COPY ./update-postgis.sh /usr/local/bin
 RUN set -ex \
     # Is the "ca-certificates" package installed? (for accessing remote raster files)
     #   https://github.com/postgis/docker-postgis/issues/307
-    dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
+    && dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
     \
     # list postgresql, postgis version
     && cat /_pgis_full_version.txt

--- a/15beta3-3.2/Dockerfile
+++ b/15beta3-3.2/Dockerfile
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION 3.2.3+dfsg-1.pgdg110+1
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*

--- a/15beta3-3.2/alpine/Dockerfile
+++ b/15beta3-3.2/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/15beta3-3.3.0rc2/alpine/Dockerfile
+++ b/15beta3-3.3.0rc2/alpine/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/15beta3-master/Dockerfile
+++ b/15beta3-master/Dockerfile
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
+ENV GDAL_GIT_HASH 0592a219d11e8da539f1bc0cc9c4ce8865a08818
 
 RUN set -ex \
     && cd /usr/src \
@@ -212,7 +212,7 @@ COPY --from=builder /usr/local /usr/local
 #ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
 ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
 ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
-ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
+ENV GDAL_GIT_HASH 0592a219d11e8da539f1bc0cc9c4ce8865a08818
 
 # Minimal command line test.
 RUN set -ex \
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 2428842e84fc6b6ce8a15fcfe9a17d888cd0eaa5
+ENV POSTGIS_GIT_HASH 22708b56de39cb6d2c53278e6a2262e487119b2f
 
 RUN set -ex \
     && apt-get update \
@@ -294,11 +294,6 @@ RUN set -ex \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    \
-    #
-    # We keep ca-certificates: for accessing remote raster files
-    #    https://github.com/postgis/docker-postgis/issues/307
-    #
     && apt-get purge -y --autoremove \
       autoconf \
       automake \
@@ -331,5 +326,11 @@ RUN set -ex \
 RUN mkdir -p /docker-entrypoint-initdb.d
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin
-RUN cat /_pgis_full_version.txt
 
+RUN set -ex \
+    # Is the "ca-certificates" package installed? (for accessing remote raster files)
+    #   https://github.com/postgis/docker-postgis/issues/307
+    dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
+    \
+    # list postgresql, postgis version
+    && cat /_pgis_full_version.txt

--- a/15beta3-master/Dockerfile
+++ b/15beta3-master/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex \
 # sfcgal
 ENV SFCGAL_VERSION master
 #current:
-#ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
+#ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
 #reverted for the last working version
 ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
 
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 1384b90602a6d2d51ed5ca0d2e28c8b4ada47aea
+ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 848bce44d308a05d082766da21ea5d9db2e79b8e
+ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 581246a1ccaf62438e20be371f82453c19d54394
+ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
 
 RUN set -ex \
     && cd /usr/src \
@@ -209,10 +209,10 @@ RUN set -ex \
 
 COPY --from=builder /usr/local /usr/local
 
-#ENV SFCGAL_GIT_HASH 8675662a2725976642d0ecffd4efcfe68e484483
-ENV PROJ_GIT_HASH 1384b90602a6d2d51ed5ca0d2e28c8b4ada47aea
-ENV GEOS_GIT_HASH 848bce44d308a05d082766da21ea5d9db2e79b8e
-ENV GDAL_GIT_HASH 581246a1ccaf62438e20be371f82453c19d54394
+#ENV SFCGAL_GIT_HASH 9801868bad3f8b97083dce24224fb2346f2f8c1f
+ENV PROJ_GIT_HASH 4cc46f72bf6943592ce7c55f147a5a51a0a2992b
+ENV GEOS_GIT_HASH 7135b0014e554fa1ec3a35309920c077355a77d0
+ENV GDAL_GIT_HASH 1ad37e7f93d357cc9370261fbd709765bac43dde
 
 # Minimal command line test.
 RUN set -ex \
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 2fca9d65ced41fe2cbe36d0f9d05d109b39d70db
+ENV POSTGIS_GIT_HASH 2428842e84fc6b6ce8a15fcfe9a17d888cd0eaa5
 
 RUN set -ex \
     && apt-get update \
@@ -294,13 +294,17 @@ RUN set -ex \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
+    \
+    #
+    # We keep ca-certificates: for accessing remote raster files
+    #    https://github.com/postgis/docker-postgis/issues/307
+    #
     && apt-get purge -y --autoremove \
       autoconf \
       automake \
       autotools-dev \
       bison \
       build-essential \
-      ca-certificates \
       cmake \
       g++ \
       git \

--- a/15beta3-master/Dockerfile
+++ b/15beta3-master/Dockerfile
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 22708b56de39cb6d2c53278e6a2262e487119b2f
+ENV POSTGIS_GIT_HASH d31888c038285d36b460e34773e5dddece27d585
 
 RUN set -ex \
     && apt-get update \
@@ -330,7 +330,7 @@ COPY ./update-postgis.sh /usr/local/bin
 RUN set -ex \
     # Is the "ca-certificates" package installed? (for accessing remote raster files)
     #   https://github.com/postgis/docker-postgis/issues/307
-    dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
+    && dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
     \
     # list postgresql, postgis version
     && cat /_pgis_full_version.txt

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -118,6 +118,10 @@ RUN set -eux \
         libstdc++ \
         pcre \
         protobuf-c \
+        \
+        # ca-certificates: for accessing remote raster files
+        #   fix https://github.com/postgis/docker-postgis/issues/307
+        ca-certificates \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -294,11 +294,6 @@ RUN set -ex \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
-    \
-    #
-    # We keep ca-certificates: for accessing remote raster files
-    #    https://github.com/postgis/docker-postgis/issues/307
-    #
     && apt-get purge -y --autoremove \
       autoconf \
       automake \
@@ -331,5 +326,11 @@ RUN set -ex \
 RUN mkdir -p /docker-entrypoint-initdb.d
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
 COPY ./update-postgis.sh /usr/local/bin
-RUN cat /_pgis_full_version.txt
 
+RUN set -ex \
+    # Is the "ca-certificates" package installed? (for accessing remote raster files)
+    #   https://github.com/postgis/docker-postgis/issues/307
+    dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
+    \
+    # list postgresql, postgis version
+    && cat /_pgis_full_version.txt

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -330,7 +330,7 @@ COPY ./update-postgis.sh /usr/local/bin
 RUN set -ex \
     # Is the "ca-certificates" package installed? (for accessing remote raster files)
     #   https://github.com/postgis/docker-postgis/issues/307
-    dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
+    && dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed" \
     \
     # list postgresql, postgis version
     && cat /_pgis_full_version.txt

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -294,13 +294,17 @@ RUN set -ex \
 # clean
     && cd / \
     && rm -rf /usr/src/postgis \
+    \
+    #
+    # We keep ca-certificates: for accessing remote raster files
+    #    https://github.com/postgis/docker-postgis/issues/307
+    #
     && apt-get purge -y --autoremove \
       autoconf \
       automake \
       autotools-dev \
       bison \
       build-essential \
-      ca-certificates \
       cmake \
       g++ \
       git \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,6 +8,10 @@ ENV POSTGIS_VERSION %%POSTGIS_VERSION%%
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
fix: https://github.com/postgis/docker-postgis/issues/307

important changes:
* `Dockerfile.template`
* `Dockerfile.alpine.template`
* `Dockerfile.master.template`

based on my local test;  minimal disk space increase is expected ( < 1MB )

```
# debian
new_postgis                                       14-3.2               77ce6bebee3d   20 seconds ago   575MB
postgis/postgis                                   14-3.2               9791b51b1ff7   4 days ago       575MB

# alpine
new_postgis                                       14-3.2-alpine        c18a9d1d4d26   3 minutes ago    395MB
postgis/postgis                                   14-3.2-alpine        128949707ecd   4 days ago       395MB

# master  - not tested .. disk space is less important.
```

disclaimer:  remote raster file access not tested;

IMHO: if the CI/CD is OK then ready to review/merge.

