### PR TITLE
update alpine3.16 -> alpine3.17

### DIFF
--- a/11-3.3/alpine/Dockerfile
+++ b/11-3.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:11-alpine3.16
+FROM postgres:11-alpine3.17
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
@@ -10,14 +10,14 @@ RUN set -eux \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
             #
-            # using only v3.16
+            # using only v3.17
             #
-            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.16 \
-            export GEOS_ALPINE_VER=3.10 ; \
-            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.16 \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.17 \
+            export GEOS_ALPINE_VER=3.11 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.17 \
             export GDAL_ALPINE_VER=3.5 ; \
-            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.16 \
-            export PROJ_ALPINE_VER=9.0 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.17 \
+            export PROJ_ALPINE_VER=9.1 ; \
             #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \

--- a/12-3.3/alpine/Dockerfile
+++ b/12-3.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12-alpine3.16
+FROM postgres:12-alpine3.17
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
@@ -10,14 +10,14 @@ RUN set -eux \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
             #
-            # using only v3.16
+            # using only v3.17
             #
-            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.16 \
-            export GEOS_ALPINE_VER=3.10 ; \
-            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.16 \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.17 \
+            export GEOS_ALPINE_VER=3.11 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.17 \
             export GDAL_ALPINE_VER=3.5 ; \
-            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.16 \
-            export PROJ_ALPINE_VER=9.0 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.17 \
+            export PROJ_ALPINE_VER=9.1 ; \
             #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \

--- a/13-3.3/alpine/Dockerfile
+++ b/13-3.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13-alpine3.16
+FROM postgres:13-alpine3.17
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
@@ -10,14 +10,14 @@ RUN set -eux \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
             #
-            # using only v3.16
+            # using only v3.17
             #
-            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.16 \
-            export GEOS_ALPINE_VER=3.10 ; \
-            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.16 \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.17 \
+            export GEOS_ALPINE_VER=3.11 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.17 \
             export GDAL_ALPINE_VER=3.5 ; \
-            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.16 \
-            export PROJ_ALPINE_VER=9.0 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.17 \
+            export PROJ_ALPINE_VER=9.1 ; \
             #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \

--- a/14-3.3/alpine/Dockerfile
+++ b/14-3.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14-alpine3.16
+FROM postgres:14-alpine3.17
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
@@ -10,14 +10,14 @@ RUN set -eux \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
             #
-            # using only v3.16
+            # using only v3.17
             #
-            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.16 \
-            export GEOS_ALPINE_VER=3.10 ; \
-            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.16 \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.17 \
+            export GEOS_ALPINE_VER=3.11 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.17 \
             export GDAL_ALPINE_VER=3.5 ; \
-            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.16 \
-            export PROJ_ALPINE_VER=9.0 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.17 \
+            export PROJ_ALPINE_VER=9.1 ; \
             #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \

--- a/14-master/Dockerfile
+++ b/14-master/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 65f60f6e27482920aa5007af5357d1f37b220b90
+ENV PROJ_GIT_HASH 94be2c69c2cd0d0e1db332755ec105c9c65737c5
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 1a224e6502d56f3d778b149daa9d70f2dad6cdf7
+ENV GEOS_GIT_HASH 4f427203bcc578fee24a4d76f59adc1c086349b0
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 66d9fe0b1a34a8992c804c2444f7f23c2436b937
+ENV GDAL_GIT_HASH bc0948f8773feab1ecf81fb0be782c548af5f089
 
 RUN set -ex \
     && cd /usr/src \
@@ -210,9 +210,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 #ENV SFCGAL_GIT_HASH df3c2ccc015d4a85ac672fc307d2c7c324cccca7
-ENV PROJ_GIT_HASH 65f60f6e27482920aa5007af5357d1f37b220b90
-ENV GEOS_GIT_HASH 1a224e6502d56f3d778b149daa9d70f2dad6cdf7
-ENV GDAL_GIT_HASH 66d9fe0b1a34a8992c804c2444f7f23c2436b937
+ENV PROJ_GIT_HASH 94be2c69c2cd0d0e1db332755ec105c9c65737c5
+ENV GEOS_GIT_HASH 4f427203bcc578fee24a4d76f59adc1c086349b0
+ENV GDAL_GIT_HASH bc0948f8773feab1ecf81fb0be782c548af5f089
 
 # Minimal command line test.
 RUN set -ex \
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 576233fd6321e6bf5eba856ec61313ac4f87f57a
+ENV POSTGIS_GIT_HASH c2a0b202492a235002deaf3fd4a82cbeb659ea1a
 
 RUN set -ex \
     && apt-get update \

--- a/15-3.3/alpine/Dockerfile
+++ b/15-3.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:15-alpine3.16
+FROM postgres:15-alpine3.17
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
@@ -10,14 +10,14 @@ RUN set -eux \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
             #
-            # using only v3.16
+            # using only v3.17
             #
-            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.16 \
-            export GEOS_ALPINE_VER=3.10 ; \
-            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.16 \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.17 \
+            export GEOS_ALPINE_VER=3.11 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.17 \
             export GDAL_ALPINE_VER=3.5 ; \
-            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.16 \
-            export PROJ_ALPINE_VER=9.0 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.17 \
+            export PROJ_ALPINE_VER=9.1 ; \
             #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \

--- a/15-master/Dockerfile
+++ b/15-master/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex \
 
 # proj
 ENV PROJ_VERSION master
-ENV PROJ_GIT_HASH 65f60f6e27482920aa5007af5357d1f37b220b90
+ENV PROJ_GIT_HASH 94be2c69c2cd0d0e1db332755ec105c9c65737c5
 
 RUN set -ex \
     && cd /usr/src \
@@ -114,7 +114,7 @@ RUN set -ex \
 
 # geos
 ENV GEOS_VERSION master
-ENV GEOS_GIT_HASH 1a224e6502d56f3d778b149daa9d70f2dad6cdf7
+ENV GEOS_GIT_HASH 4f427203bcc578fee24a4d76f59adc1c086349b0
 
 RUN set -ex \
     && cd /usr/src \
@@ -131,7 +131,7 @@ RUN set -ex \
 
 # gdal
 ENV GDAL_VERSION master
-ENV GDAL_GIT_HASH 66d9fe0b1a34a8992c804c2444f7f23c2436b937
+ENV GDAL_GIT_HASH bc0948f8773feab1ecf81fb0be782c548af5f089
 
 RUN set -ex \
     && cd /usr/src \
@@ -210,9 +210,9 @@ RUN set -ex \
 COPY --from=builder /usr/local /usr/local
 
 #ENV SFCGAL_GIT_HASH df3c2ccc015d4a85ac672fc307d2c7c324cccca7
-ENV PROJ_GIT_HASH 65f60f6e27482920aa5007af5357d1f37b220b90
-ENV GEOS_GIT_HASH 1a224e6502d56f3d778b149daa9d70f2dad6cdf7
-ENV GDAL_GIT_HASH 66d9fe0b1a34a8992c804c2444f7f23c2436b937
+ENV PROJ_GIT_HASH 94be2c69c2cd0d0e1db332755ec105c9c65737c5
+ENV GEOS_GIT_HASH 4f427203bcc578fee24a4d76f59adc1c086349b0
+ENV GDAL_GIT_HASH bc0948f8773feab1ecf81fb0be782c548af5f089
 
 # Minimal command line test.
 RUN set -ex \
@@ -230,7 +230,7 @@ RUN ogr2ogr --formats | grep -q "PostgreSQL/PostGIS" && exit 0 \
 
 # install postgis
 ENV POSTGIS_VERSION master
-ENV POSTGIS_GIT_HASH 576233fd6321e6bf5eba856ec61313ac4f87f57a
+ENV POSTGIS_GIT_HASH c2a0b202492a235002deaf3fd4a82cbeb659ea1a
 
 RUN set -ex \
     && apt-get update \

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -1,4 +1,4 @@
-FROM postgres:%%PG_MAJOR%%-alpine3.16
+FROM postgres:%%PG_MAJOR%%-alpine3.17
 
 LABEL maintainer="PostGIS Project - https://postgis.net"
 
@@ -10,14 +10,14 @@ RUN set -eux \
     &&  if   [ $(printf %.1s "$POSTGIS_VERSION") == 3 ]; then \
             set -eux ; \
             #
-            # using only v3.16
+            # using only v3.17
             #
-            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.16 \
-            export GEOS_ALPINE_VER=3.10 ; \
-            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.16 \
+            #GEOS: https://pkgs.alpinelinux.org/packages?name=geos&branch=v3.17 \
+            export GEOS_ALPINE_VER=3.11 ; \
+            #GDAL: https://pkgs.alpinelinux.org/packages?name=gdal&branch=v3.17 \
             export GDAL_ALPINE_VER=3.5 ; \
-            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.16 \
-            export PROJ_ALPINE_VER=9.0 ; \
+            #PROJ: https://pkgs.alpinelinux.org/packages?name=proj&branch=v3.17 \
+            export PROJ_ALPINE_VER=9.1 ; \
             #
         elif [ $(printf %.1s "$POSTGIS_VERSION") == 2 ]; then \
             set -eux ; \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Note: As of PostGIS v3.x, raster has been factored out into a separate extension
 
 Unless `-e POSTGRES_DB` is passed to the container at startup time, this database will be named after the admin user (either `postgres` or the user specified with `-e POSTGRES_USER`). If you would prefer to use the older template database mechanism for enabling PostGIS, the image also provides a PostGIS-enabled template database called `template_postgis`.
 
-# Versions ( 2022-11-17 )
+# Versions ( 2022-12-09 )
 
 Recomended version for the new users: `postgis/postgis:15-3.3`
 
@@ -38,17 +38,17 @@ Recomended version for the new users: `postgis/postgis:15-3.3`
 ### Alpine based
 
 * base os = [Alpine linux](https://alpinelinux.org/): designed to be small, simple and secure ; [musl libc](https://musl.libc.org/) based
-* alpine:3.16; geos=3.10; gdal=3.5; proj=9.0
+* alpine:3.17; geos=3.11; gdal=3.5; proj=9.1
 * Postgis has been compiled from source ; harder to extend
 * no SFCGAL support yet; (`postgis_sfcgal` is not working )
 
 | DockerHub image | Dockerfile | OS | Postgres | PostGIS |
 | --------------- | ---------- | -- | -------- | ------- |
-| [postgis/postgis:11-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/11-3.3/alpine/Dockerfile) | alpine:3.16 | 11 | 3.3.2 |
-| [postgis/postgis:12-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.3/alpine/Dockerfile) | alpine:3.16 | 12 | 3.3.2 |
-| [postgis/postgis:13-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.3/alpine/Dockerfile) | alpine:3.16 | 13 | 3.3.2 |
-| [postgis/postgis:14-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.3/alpine/Dockerfile) | alpine:3.16 | 14 | 3.3.2 |
-| [postgis/postgis:15-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15-3.3/alpine/Dockerfile) | alpine:3.16 | 15 | 3.3.2 |
+| [postgis/postgis:11-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=11-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/11-3.3/alpine/Dockerfile) | alpine:3.17 | 11 | 3.3.2 |
+| [postgis/postgis:12-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.3/alpine/Dockerfile) | alpine:3.17 | 12 | 3.3.2 |
+| [postgis/postgis:13-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.3/alpine/Dockerfile) | alpine:3.17 | 13 | 3.3.2 |
+| [postgis/postgis:14-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.3/alpine/Dockerfile) | alpine:3.17 | 14 | 3.3.2 |
+| [postgis/postgis:15-3.3-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15-3.3-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15-3.3/alpine/Dockerfile) | alpine:3.17 | 15 | 3.3.2 |
 
 ### Test images
 

--- a/update.sh
+++ b/update.sh
@@ -23,6 +23,7 @@ githubrepolink="https://github.com/postgis/docker-postgis/blob/master"
 # sort version numbers with highest last (so it goes first in .travis.yml)
 IFS=$'\n'; versions=( $(echo "${versions[*]}" | sort -V) ); unset IFS
 
+defaultAlpinenSuite='3.17'
 defaultDebianSuite='bullseye-slim'
 declare -A debianSuite=(
     # https://github.com/docker-library/postgres/issues/582
@@ -170,7 +171,7 @@ for version in "${versions[@]}"; do
             mv "$version/$variant/Dockerfile.alpine.template" "$version/$variant/Dockerfile"
             sed -i 's/%%PG_MAJOR%%/'"$postgresVersion"'/g; s/%%POSTGIS_VERSION%%/'"$srcVersion"'/g; s/%%POSTGIS_SHA256%%/'"$srcSha256"'/g' "$version/$variant/Dockerfile"
 
-            echo "| [postgis/postgis:${version}-${variant}](${dockerhublink}${version}-${variant}) | [Dockerfile](${githubrepolink}/${version}/${variant}/Dockerfile) | alpine:3.16 | ${postgresVersion} | ${postgisDocSrc} |" >> _dockerlists_${optimized}.md
+            echo "| [postgis/postgis:${version}-${variant}](${dockerhublink}${version}-${variant}) | [Dockerfile](${githubrepolink}/${version}/${variant}/Dockerfile) | alpine:${defaultAlpinenSuite} | ${postgresVersion} | ${postgisDocSrc} |" >> _dockerlists_${optimized}.md
         )
     done
 done


### PR DESCRIPTION
fix: https://github.com/postgis/docker-postgis/issues/328

upstream docker Postgres image updated to alpine 3.17 ( `docker-library/postgres` ) 
so no upstream support for Postgres alpine3.16 in the future!

- update "Dockerfile.alpine.template"
- update "update.sh"
- update "README.md"
- run "make update"
- commit the changes


local:   `14-3.3-alpine` tested and looks OK.
```sql
 PostgreSQL 14.6 on x86_64-pc-linux-musl, compiled by gcc (Alpine 12.2.1_git20220924-r4) 12.2.1 20220924, 64-bit
 POSTGIS="3.3.2 0" [EXTENSION] PGSQL="140" GEOS="3.11.1-CAPI-1.17.1" PROJ="9.1.0" LIBXML="2.10.3" LIBJSON="0.16" LIBPROTOBUF="1.4.1" WAGYU="0.5.0 (Internal)"
```
