### PR TITLE
Update Dockerfile.master.template: fetch `libcgal-dev` 5.5.1 from Debian testing in order to build SCFGAL 1.4.1

### DIFF
--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -61,12 +61,14 @@ RUN set -ex \
 
 # sfcgal
 ENV SFCGAL_VERSION master
-#current:
-#ENV SFCGAL_GIT_HASH %%SFCGAL_GIT_HASH%%
-#reverted for the last working version
-ENV SFCGAL_GIT_HASH e1f5cd801f8796ddb442c06c11ce8c30a7eed2c5
+# SCFGAL 1.4.1 tag (latest stable release: needs libcgal-dev >= 5.3)
+ENV SFCGAL_GIT_HASH 2d6a1a89552f14fe2926038b7237686bb9e5472e
 
 RUN set -ex \
+    # Fetch libcgal-dev from Debian testing (sid)
+    && echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends libcgal-dev \
     && mkdir -p /usr/src \
     && cd /usr/src \
     && git clone https://gitlab.com/Oslandia/SFCGAL.git \


### PR DESCRIPTION
+ Set SFCGAL git hash equals to version tag 1.4.1 from Oslandia's repository,
+ Specifically fetch libcgal-dev from Debian testing (sid) to be able to install SFCGAL 1.4.x,
+ Clean out commented code.


This should fix: 
- https://github.com/postgis/docker-postgis/issues/333
- https://github.com/postgis/docker-postgis/discussions/335

- [ ] TODO: I would say it could be worth to programmatically set the SFCGAL tag in the same way than the PROJ or GEOS ones when updating the versioned images. Or even to build CGAL itself from sources prior to SCFGAL?

----

This is the full postgis version string when I currently build the image using the proposed PR on `15-master`:
```sql
POSTGIS="3.4.0dev 3.3.0rc2-390-gc2a0b2024"
  [EXTENSION]
      PGSQL="150"
      GEOS="3.12.0dev-CAPI-1.18.0"
      SFCGAL="SFCGAL 1.4.1, CGAL 5.5.1, BOOST 1.74.0" # <--- updated!
      PROJ="9.2.0"
      LIBXML="2.9.10"
      LIBJSON="0.15"
      LIBPROTOBUF="1.3.3"
      WAGYU="0.5.0 (Internal)"
      TOPOLOGY
```