### PR TITLE
Update Debian PostGIS to 3.5.1 via update.sh

### DIFF
--- a/12-3.5/Dockerfile
+++ b/12-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:12-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.0+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 12 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 12 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.0+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/13-3.5/Dockerfile
+++ b/13-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:13-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.0+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 13 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 13 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.0+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/14-3.5/Dockerfile
+++ b/14-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:14-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.0+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 14 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 14 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.0+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/15-3.5/Dockerfile
+++ b/15-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:15-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.0+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 15 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 15 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.0+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/16-3.5/Dockerfile
+++ b/16-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:16-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.0+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 16 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 16 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.0+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/16-master/Dockerfile
+++ b/16-master/Dockerfile
@@ -86,7 +86,7 @@ ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 # cgal & sfcgal
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH f5f5dc72441cd89d5e54ba7026f0524bb07571f3
+ENV CGAL_GIT_HASH 1c04f5768caddb5598c37dee342e72ff6c0c83c5
 ENV SFCGAL_GIT_HASH 38d5c0f5af3eaf38998e53d959994a346deb1c64
 RUN set -ex \
     && mkdir -p /usr/src \
@@ -120,7 +120,7 @@ RUN set -ex \
     && rm -fr /usr/src/cgal
 
 # proj
-ENV PROJ_GIT_HASH 3421b04700627e2f83ebc3e2cb413eefe0fdb923
+ENV PROJ_GIT_HASH 5500ba73a99c8b64778628ac50e03c51a984a5c6
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/PROJ.git \
@@ -166,7 +166,7 @@ RUN set -ex \
     && rm -fr /usr/src/geos
 
 # gdal
-ENV GDAL_GIT_HASH f314d4b6bc0b70582fd1cb07f8ae95d01e9c8a86
+ENV GDAL_GIT_HASH 0fbf2b8a968178bc808997df1ebd127155d701c2
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/gdal.git \
@@ -299,11 +299,11 @@ COPY --from=builder /usr/local /usr/local
 
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH f5f5dc72441cd89d5e54ba7026f0524bb07571f3
+ENV CGAL_GIT_HASH 1c04f5768caddb5598c37dee342e72ff6c0c83c5
 ENV SFCGAL_GIT_HASH 38d5c0f5af3eaf38998e53d959994a346deb1c64
-ENV PROJ_GIT_HASH 3421b04700627e2f83ebc3e2cb413eefe0fdb923
+ENV PROJ_GIT_HASH 5500ba73a99c8b64778628ac50e03c51a984a5c6
 ENV GEOS_GIT_HASH e1c9a7c5c6819383bb57fb15a000cdb06dd47600
-ENV GDAL_GIT_HASH f314d4b6bc0b70582fd1cb07f8ae95d01e9c8a86
+ENV GDAL_GIT_HASH 0fbf2b8a968178bc808997df1ebd127155d701c2
 
 # Minimal command line test ( fail fast )
 RUN set -ex \

--- a/17-3.5/Dockerfile
+++ b/17-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:17-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.0+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 17 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 17 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.0+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/17-master/Dockerfile
+++ b/17-master/Dockerfile
@@ -86,7 +86,7 @@ ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 # cgal & sfcgal
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH f5f5dc72441cd89d5e54ba7026f0524bb07571f3
+ENV CGAL_GIT_HASH 1c04f5768caddb5598c37dee342e72ff6c0c83c5
 ENV SFCGAL_GIT_HASH 38d5c0f5af3eaf38998e53d959994a346deb1c64
 RUN set -ex \
     && mkdir -p /usr/src \
@@ -120,7 +120,7 @@ RUN set -ex \
     && rm -fr /usr/src/cgal
 
 # proj
-ENV PROJ_GIT_HASH 3421b04700627e2f83ebc3e2cb413eefe0fdb923
+ENV PROJ_GIT_HASH 5500ba73a99c8b64778628ac50e03c51a984a5c6
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/PROJ.git \
@@ -166,7 +166,7 @@ RUN set -ex \
     && rm -fr /usr/src/geos
 
 # gdal
-ENV GDAL_GIT_HASH f314d4b6bc0b70582fd1cb07f8ae95d01e9c8a86
+ENV GDAL_GIT_HASH 0fbf2b8a968178bc808997df1ebd127155d701c2
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/gdal.git \
@@ -299,11 +299,11 @@ COPY --from=builder /usr/local /usr/local
 
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH f5f5dc72441cd89d5e54ba7026f0524bb07571f3
+ENV CGAL_GIT_HASH 1c04f5768caddb5598c37dee342e72ff6c0c83c5
 ENV SFCGAL_GIT_HASH 38d5c0f5af3eaf38998e53d959994a346deb1c64
-ENV PROJ_GIT_HASH 3421b04700627e2f83ebc3e2cb413eefe0fdb923
+ENV PROJ_GIT_HASH 5500ba73a99c8b64778628ac50e03c51a984a5c6
 ENV GEOS_GIT_HASH e1c9a7c5c6819383bb57fb15a000cdb06dd47600
-ENV GDAL_GIT_HASH f314d4b6bc0b70582fd1cb07f8ae95d01e9c8a86
+ENV GDAL_GIT_HASH 0fbf2b8a968178bc808997df1ebd127155d701c2
 
 # Minimal command line test ( fail fast )
 RUN set -ex \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This image ensures that the default database created by the parent `postgres` im
 
 Unless `-e POSTGRES_DB` is passed to the container at startup time, this database will be named after the admin user (either `postgres` or the user specified with `-e POSTGRES_USER`). If you would prefer to use the older template database mechanism for enabling PostGIS, the image also provides a PostGIS-enabled template database called `template_postgis`.
 
-# Versions (2024-12-24)
+# Versions (2025-01-03)
 
 Supported architecture: `amd64` (also known as X86-64)"
 
@@ -34,12 +34,12 @@ Recommended versions for new users are: `postgis/postgis:17-3.5`, `postgis/postg
 
 | DockerHub image | Dockerfile | OS | Postgres | PostGIS |
 | --------------- | ---------- | -- | -------- | ------- |
-| [postgis/postgis:12-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.5/Dockerfile) | debian:bullseye | 12 | 3.5.0 |
-| [postgis/postgis:13-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.5/Dockerfile) | debian:bullseye | 13 | 3.5.0 |
-| [postgis/postgis:14-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.5/Dockerfile) | debian:bullseye | 14 | 3.5.0 |
-| [postgis/postgis:15-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15-3.5/Dockerfile) | debian:bullseye | 15 | 3.5.0 |
-| [postgis/postgis:16-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=16-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/16-3.5/Dockerfile) | debian:bullseye | 16 | 3.5.0 |
-| [postgis/postgis:17-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=17-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/17-3.5/Dockerfile) | debian:bullseye | 17 | 3.5.0 |
+| [postgis/postgis:12-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.5/Dockerfile) | debian:bullseye | 12 | 3.5.1 |
+| [postgis/postgis:13-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.5/Dockerfile) | debian:bullseye | 13 | 3.5.1 |
+| [postgis/postgis:14-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.5/Dockerfile) | debian:bullseye | 14 | 3.5.1 |
+| [postgis/postgis:15-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15-3.5/Dockerfile) | debian:bullseye | 15 | 3.5.1 |
+| [postgis/postgis:16-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=16-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/16-3.5/Dockerfile) | debian:bullseye | 16 | 3.5.1 |
+| [postgis/postgis:17-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=17-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/17-3.5/Dockerfile) | debian:bullseye | 17 | 3.5.1 |
 
 ### Alpine based
 


### PR DESCRIPTION
Context: The PostgreSQL Debian package for PostGIS has been updated to version 3.5.1+dfsg-1.pgdg+2. (  [Announcement: pgsql-pkg-debian](https://www.postgresql.org/message-id/E1tT6O0-0039Ua-DC%40atalia.postgresql.org) )

Changes in this PR:
* `./update.sh` - to fetch and apply updates.
* Manually updated `./README.md` to reflect the latest PostGIS version and changes. 


