### PR TITLE
Update Debian PostGIS to 3.5.2 via update.sh

### DIFF
--- a/12-3.5/Dockerfile
+++ b/12-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:12-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 12 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 12 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.2+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/13-3.5/Dockerfile
+++ b/13-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:13-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 13 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 13 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.2+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/14-3.5/Dockerfile
+++ b/14-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:14-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 14 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 14 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.2+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/15-3.5/Dockerfile
+++ b/15-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:15-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 15 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 15 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.2+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/16-3.5/Dockerfile
+++ b/16-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:16-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 16 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 16 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.2+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/16-master/Dockerfile
+++ b/16-master/Dockerfile
@@ -86,7 +86,7 @@ ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 # cgal & sfcgal
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH b4a8c00e096add9e03cef6f1631be3e00f4c6768
+ENV CGAL_GIT_HASH c313da8791a99db984d4efcf061cde9a83d05418
 ENV SFCGAL_GIT_HASH 38d5c0f5af3eaf38998e53d959994a346deb1c64
 RUN set -ex \
     && mkdir -p /usr/src \
@@ -150,7 +150,7 @@ RUN set -ex \
     && rm -fr /usr/src/PROJ
 
 # geos
-ENV GEOS_GIT_HASH af08e9d5318ad823072d17908058c6b1aa9125b9
+ENV GEOS_GIT_HASH b23952c3618c590c6e9c7c4e9816447090613975
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/libgeos/geos.git \
@@ -166,7 +166,7 @@ RUN set -ex \
     && rm -fr /usr/src/geos
 
 # gdal
-ENV GDAL_GIT_HASH 63cd33ad48045f320c110dd033c076e9d81d7a5c
+ENV GDAL_GIT_HASH ae464d424efe00bc275478c0c8813aba309a0e56
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/gdal.git \
@@ -299,11 +299,11 @@ COPY --from=builder /usr/local /usr/local
 
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH b4a8c00e096add9e03cef6f1631be3e00f4c6768
+ENV CGAL_GIT_HASH c313da8791a99db984d4efcf061cde9a83d05418
 ENV SFCGAL_GIT_HASH 38d5c0f5af3eaf38998e53d959994a346deb1c64
 ENV PROJ_GIT_HASH c34044742a5f0b67d12e613250601d1cbefcebbd
-ENV GEOS_GIT_HASH af08e9d5318ad823072d17908058c6b1aa9125b9
-ENV GDAL_GIT_HASH 63cd33ad48045f320c110dd033c076e9d81d7a5c
+ENV GEOS_GIT_HASH b23952c3618c590c6e9c7c4e9816447090613975
+ENV GDAL_GIT_HASH ae464d424efe00bc275478c0c8813aba309a0e56
 
 # Minimal command line test ( fail fast )
 RUN set -ex \
@@ -322,7 +322,7 @@ RUN set -ex \
             || echo "ogr2ogr missing PostgreSQL driver" && exit 1
 
 # install postgis
-ENV POSTGIS_GIT_HASH 2845d3f37896e64ad24a2ee6863213b297da1301
+ENV POSTGIS_GIT_HASH 607b81d5af061e4a8dd76ee68f3e601d87107a00
 
 RUN set -ex \
     && apt-get update \

--- a/17-3.5/Dockerfile
+++ b/17-3.5/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:17-bullseye
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 17 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 17 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.2+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/17-master/Dockerfile
+++ b/17-master/Dockerfile
@@ -86,7 +86,7 @@ ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 # cgal & sfcgal
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH b4a8c00e096add9e03cef6f1631be3e00f4c6768
+ENV CGAL_GIT_HASH c313da8791a99db984d4efcf061cde9a83d05418
 ENV SFCGAL_GIT_HASH 38d5c0f5af3eaf38998e53d959994a346deb1c64
 RUN set -ex \
     && mkdir -p /usr/src \
@@ -150,7 +150,7 @@ RUN set -ex \
     && rm -fr /usr/src/PROJ
 
 # geos
-ENV GEOS_GIT_HASH af08e9d5318ad823072d17908058c6b1aa9125b9
+ENV GEOS_GIT_HASH b23952c3618c590c6e9c7c4e9816447090613975
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/libgeos/geos.git \
@@ -166,7 +166,7 @@ RUN set -ex \
     && rm -fr /usr/src/geos
 
 # gdal
-ENV GDAL_GIT_HASH 63cd33ad48045f320c110dd033c076e9d81d7a5c
+ENV GDAL_GIT_HASH ae464d424efe00bc275478c0c8813aba309a0e56
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/gdal.git \
@@ -299,11 +299,11 @@ COPY --from=builder /usr/local /usr/local
 
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH b4a8c00e096add9e03cef6f1631be3e00f4c6768
+ENV CGAL_GIT_HASH c313da8791a99db984d4efcf061cde9a83d05418
 ENV SFCGAL_GIT_HASH 38d5c0f5af3eaf38998e53d959994a346deb1c64
 ENV PROJ_GIT_HASH c34044742a5f0b67d12e613250601d1cbefcebbd
-ENV GEOS_GIT_HASH af08e9d5318ad823072d17908058c6b1aa9125b9
-ENV GDAL_GIT_HASH 63cd33ad48045f320c110dd033c076e9d81d7a5c
+ENV GEOS_GIT_HASH b23952c3618c590c6e9c7c4e9816447090613975
+ENV GDAL_GIT_HASH ae464d424efe00bc275478c0c8813aba309a0e56
 
 # Minimal command line test ( fail fast )
 RUN set -ex \
@@ -322,7 +322,7 @@ RUN set -ex \
             || echo "ogr2ogr missing PostgreSQL driver" && exit 1
 
 # install postgis
-ENV POSTGIS_GIT_HASH 2845d3f37896e64ad24a2ee6863213b297da1301
+ENV POSTGIS_GIT_HASH 607b81d5af061e4a8dd76ee68f3e601d87107a00
 
 RUN set -ex \
     && apt-get update \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This image ensures that the default database created by the parent `postgres` im
 
 Unless `-e POSTGRES_DB` is passed to the container at startup time, this database will be named after the admin user (either `postgres` or the user specified with `-e POSTGRES_USER`). If you would prefer to use the older template database mechanism for enabling PostGIS, the image also provides a PostGIS-enabled template database called `template_postgis`.
 
-# Versions (2025-01-03)
+# Versions (2025-01-23)
 
 Supported architecture: `amd64` (also known as X86-64)"
 
@@ -34,12 +34,12 @@ Recommended versions for new users are: `postgis/postgis:17-3.5`, `postgis/postg
 
 | DockerHub image | Dockerfile | OS | Postgres | PostGIS |
 | --------------- | ---------- | -- | -------- | ------- |
-| [postgis/postgis:12-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.5/Dockerfile) | debian:bullseye | 12 | 3.5.1 |
-| [postgis/postgis:13-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.5/Dockerfile) | debian:bullseye | 13 | 3.5.1 |
-| [postgis/postgis:14-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.5/Dockerfile) | debian:bullseye | 14 | 3.5.1 |
-| [postgis/postgis:15-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15-3.5/Dockerfile) | debian:bullseye | 15 | 3.5.1 |
-| [postgis/postgis:16-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=16-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/16-3.5/Dockerfile) | debian:bullseye | 16 | 3.5.1 |
-| [postgis/postgis:17-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=17-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/17-3.5/Dockerfile) | debian:bullseye | 17 | 3.5.1 |
+| [postgis/postgis:12-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.5/Dockerfile) | debian:bullseye | 12 | 3.5.2 |
+| [postgis/postgis:13-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.5/Dockerfile) | debian:bullseye | 13 | 3.5.2 |
+| [postgis/postgis:14-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.5/Dockerfile) | debian:bullseye | 14 | 3.5.2 |
+| [postgis/postgis:15-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15-3.5/Dockerfile) | debian:bullseye | 15 | 3.5.2 |
+| [postgis/postgis:16-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=16-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/16-3.5/Dockerfile) | debian:bullseye | 16 | 3.5.2 |
+| [postgis/postgis:17-3.5](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=17-3.5) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/17-3.5/Dockerfile) | debian:bullseye | 17 | 3.5.2 |
 
 ### Alpine based
 
@@ -49,12 +49,12 @@ Recommended versions for new users are: `postgis/postgis:17-3.5`, `postgis/postg
 
 | DockerHub image | Dockerfile | OS | Postgres | PostGIS |
 | --------------- | ---------- | -- | -------- | ------- |
-| [postgis/postgis:12-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.5/alpine/Dockerfile) | alpine:3.21 | 12 | 3.5.1 |
-| [postgis/postgis:13-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.5/alpine/Dockerfile) | alpine:3.21 | 13 | 3.5.1 |
-| [postgis/postgis:14-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.5/alpine/Dockerfile) | alpine:3.21 | 14 | 3.5.1 |
-| [postgis/postgis:15-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15-3.5/alpine/Dockerfile) | alpine:3.21 | 15 | 3.5.1 |
-| [postgis/postgis:16-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=16-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/16-3.5/alpine/Dockerfile) | alpine:3.21 | 16 | 3.5.1 |
-| [postgis/postgis:17-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=17-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/17-3.5/alpine/Dockerfile) | alpine:3.21 | 17 | 3.5.1 |
+| [postgis/postgis:12-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=12-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/12-3.5/alpine/Dockerfile) | alpine:3.21 | 12 | 3.5.2 |
+| [postgis/postgis:13-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=13-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/13-3.5/alpine/Dockerfile) | alpine:3.21 | 13 | 3.5.2 |
+| [postgis/postgis:14-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=14-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/14-3.5/alpine/Dockerfile) | alpine:3.21 | 14 | 3.5.2 |
+| [postgis/postgis:15-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=15-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/15-3.5/alpine/Dockerfile) | alpine:3.21 | 15 | 3.5.2 |
+| [postgis/postgis:16-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=16-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/16-3.5/alpine/Dockerfile) | alpine:3.21 | 16 | 3.5.2 |
+| [postgis/postgis:17-3.5-alpine](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&name=17-3.5-alpine) | [Dockerfile](https://github.com/postgis/docker-postgis/blob/master/17-3.5/alpine/Dockerfile) | alpine:3.21 | 17 | 3.5.2 |
 
 ### Test images
 


### PR DESCRIPTION
* triggered by: "postgis updated to version 3.5.2+dfsg-1.pgdg+1" 
   *  https://www.postgresql.org/message-id/E1taxE3-0037gs-SL%40atalia.postgresql.org*
* with `./update.sh`  
* README.md updated manually.

( Waiting for CI )