### PR TITLE
Multiplatform build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,12 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v4
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build docker image for ${{ env.VERSION }} ${{ env.VARIANT }}
       run: make test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
     env:
       VERSION: ${{ matrix.postgres }}-${{ matrix.postgis }}
       VARIANT: ${{ matrix.variant }}
+      PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/386
 
     steps:
     - name: Checkout source

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,13 @@ IMAGE_NAME ?= postgis
 DOCKER=docker
 DOCKERHUB_DESC_IMG=peterevans/dockerhub-description:latest
 
+# choice between buildx and build depending on the PLATFORMS variable
+ifdef PLATFORMS
+  BUILD := buildx build --platform $(PLATFORMS)
+else
+  BUILD := build
+endif
+
 GIT=git
 OFFIMG_LOCAL_CLONE=$(HOME)/official-images
 OFFIMG_REPO_URL=https://github.com/docker-library/official-images.git
@@ -76,12 +83,12 @@ update:
 define build-version
 build-$1:
 ifeq ($(do_default),true)
-	$(DOCKER) build --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) $1
+	$(DOCKER) $(BUILD) --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) $1
 	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)
 endif
 ifeq ($(do_alpine),true)
 ifneq ("$(wildcard $1/alpine)","")
-	$(DOCKER) build --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine $1/alpine
+	$(DOCKER) $(BUILD) --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine $1/alpine
 	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine
 endif
 endif

--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ This Docker-PostGIS project [is part of the PostGIS group](https://postgis.net/d
 * If you have a major change in mind, we kindly ask you to start a discussion about it first.
 * After making changes to the templates, please run the `./update.sh` script.
 
+## Building Docker Images
+
+To build the all Docker images on your local machine, run:
+
+```sh
+make build
+```
+
+To build for a different platform, install `docker buildx` and run:
+
+```sh
+export PLATFORMS="linux/arm64,linux/amd64"
+make build
+```
+
 ## Code of Conduct
 
 see: https://postgis.net/community/conduct/


### PR DESCRIPTION
This makes a start at fixing #216.

Changes:

- Add buildx option to Makefile
- Add buildx install to github action
- Add PLATFORMS variable to github actions
- Document building with `make` in README

I will check the platforms now...