### PR TITLE
Preliminary updates to CI on the road to building maintainable multiplatform container images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
   make-docker-images:
     strategy:
       matrix:
+        runner-platform: ['ubuntu-24.04', 'ubuntu-24.04-arm']
         postgres: [13, 14, 15, 16, 17]
         postgis: ['3.5']
         variant: [default, alpine]
@@ -22,18 +23,60 @@ jobs:
           - postgres: 16
             postgis: master
             variant: default
+            runner-platform: 'ubuntu-24.04'
           - postgres: 17
             postgis: master
             variant: default
+            runner-platform: 'ubuntu-24.04'
+          - postgres: 16
+            postgis: master
+            variant: default
+            runner-platform: 'ubuntu-24.04-arm'
+          - postgres: 17
+            postgis: master
+            variant: default
+            runner-platform: 'ubuntu-24.04-arm'
 
-    name: Build docker image for ${{ matrix.postgres }}-${{ matrix.postgis }} variant ${{ matrix.variant }}
-    runs-on: ubuntu-24.04
+    name: Build docker image for ${{ matrix.postgres }}-${{ matrix.postgis }} variant ${{ matrix.variant }} on ${{ matrix.runner-platform }}
+    runs-on: ${{ matrix.runner-platform }}
     continue-on-error: ${{ matrix.postgis == 'master' }}
     env:
       VERSION: ${{ matrix.postgres }}-${{ matrix.postgis }}
       VARIANT: ${{ matrix.variant }}
+      DOCKER_APT_PKG_VER: '5:28.0.0-1~ubuntu.24.04~noble'
 
     steps:
+    - name: Install/config specific version of Docker packages
+      run: |
+        echo "***** Removing any currently installed conflicting packages..."
+        for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+        echo "***** Setting up Docker's APT repo..."
+        sudo apt-get update
+        sudo apt-get install ca-certificates curl
+        sudo install -m 0755 -d /etc/apt/keyrings
+        sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        sudo chmod a+r /etc/apt/keyrings/docker.asc
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+          $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+        echo "***** Installing Docker packages..."
+        sudo apt-get install docker-ce=${{ env.DOCKER_APT_PKG_VER }} docker-ce-cli=${{ env.DOCKER_APT_PKG_VER }} containerd.io docker-buildx-plugin docker-compose-plugin
+        echo "***** Verifying initial Docker installation..."
+        docker run hello-world
+        echo "***** Displaying Docker information..."
+        docker info
+        echo "***** Configuring Docker for containerd image store..."
+        echo "{ \"features\": { \"containerd-snapshotter\": true }}" | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+        docker info -f '{{ .DriverStatus }}'
+
+    - name: Load binfmt platforms for QEMU
+      run: |
+        docker run --privileged --rm tonistiigi/binfmt --install all
+        docker images --tree
+
     - name: Checkout source
       uses: actions/checkout@v4
 
@@ -48,7 +91,8 @@ jobs:
         password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
     - name: Push docker image to dockerhub
-      if: ${{  (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request')  }}
+      # !!!! ONLY push the images when built on ubuntu-24.04 x86 runner for now, NOT for ubuntu-24.04-arm runners
+      if: ${{  (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && ( matrix.runner-platform == 'ubuntu-24.04' ) }}
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
- Build on both x86 and arm runners
- Pin version of docker engine to be used for image builds to a specific version
- Configure Docker Engine on runner to use containerd image store (details [here](https://docs.docker.com/build/building/multi-platform/#prerequisites))
- Use binfmt container to install emulation platforms (details [here](https://docs.docker.com/build/building/multi-platform/#qemu))
- Only push x86 container images for now

This PR only modifies CI for now.  Detailed change explanations are as follows:

The `make-docker-images` job matrix now defines a `runner-platform` variable with definitions for a Ubuntu x86 and Ubuntu arm runner.  This added variable results in the job now being run on two separate runners, building images for each platform, but a condition is defined on the subsequent "push" step which intentionally limits only the x86 images being pushed to DockerHub for now and not the arm images.

A step has been added to install a specific version of Docker Engine on the runner and configure it to use the containerd image store which is needed to facilitate multiplatform image handling.  It seems the GHA Ubuntu runners already install Docker Engine from Docker's APT repos, but with an older version.  In order to keep the CI builds more stable, this PR defines an environment variable specifying the exact version to be installed.  The initial value for the variable is the current latest Docker Engine release as of 2024-02-25.

A step has been added to run the "binfmt" container image on the runner so that QEMU can be used to build container images for other platforms.  Currently this QEMU functionally is NOT used and has proven to be problematic with the postgis builds.

As stated above, the step which pushes images to DockerHub has been modified to include a condition to only push images built on the x86 runners.  This is intended to be temporary until multiplatform composite images are rolled into the CI.