### PR TITLE
Feat/multiarch and action qol

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,14 +29,6 @@ jobs:
             postgis: master
             variant: default
             runner-platform: 'ubuntu-24.04'
-          - postgres: 16
-            postgis: master
-            variant: default
-            runner-platform: 'ubuntu-24.04-arm'
-          - postgres: 17
-            postgis: master
-            variant: default
-            runner-platform: 'ubuntu-24.04-arm'
 
     name: Build docker image for ${{ matrix.postgres }}-${{ matrix.postgis }} variant ${{ matrix.variant }} on ${{ matrix.runner-platform }}
     runs-on: ${{ matrix.runner-platform }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,7 @@ jobs:
       if: ${{  (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && ( matrix.runner-platform == 'ubuntu-24.04' ) }}
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        REPO_NAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       run: make push
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,8 +92,6 @@ jobs:
         password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
     - name: Push docker image to dockerhub
-      # !!!! ONLY push the images when built on ubuntu-24.04 x86 runner for now, NOT for ubuntu-24.04-arm runners
-      if: ${{  (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && ( matrix.runner-platform == 'ubuntu-24.04' ) }}
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         REPO_NAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
   make-docker-images:
     strategy:
       matrix:
-        runner-platform: ['ubuntu-24.04', 'ubuntu-24.04-arm']
+        runner-platform: ['ubuntu-24.04']
         postgres: [13, 14, 15, 16, 17]
         postgis: ['3.5']
         variant: [default, alpine]
@@ -93,7 +93,7 @@ jobs:
 
     - name: Push docker image to dockerhub
       # !!!! ONLY push the images when built on ubuntu-24.04 x86 runner for now, NOT for ubuntu-24.04-arm runners
-      if: ${{  (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && ( matrix.runner-platform == 'ubuntu-24.04-arm' ) }}
+      if: ${{  (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && ( matrix.runner-platform == 'ubuntu-24.04' ) }}
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         REPO_NAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Docker PostGIS CI
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
   schedule:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
 
     - name: Push docker image to dockerhub
       # !!!! ONLY push the images when built on ubuntu-24.04 x86 runner for now, NOT for ubuntu-24.04-arm runners
-      if: ${{  (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && ( matrix.runner-platform == 'ubuntu-24.04' ) }}
+      if: ${{  (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && ( matrix.runner-platform == 'ubuntu-24.04-arm' ) }}
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         REPO_NAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 # When processing the rules for tagging and pushing container images with the
 # "latest" tag, the following variable will be the version that is considered
 # to be the latest.
@@ -76,13 +75,13 @@ update:
 define build-version
 build-$1:
 ifeq ($(do_default),true)
-	$(DOCKER) build --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) $1
-	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)
+	$(DOCKER) buildx build --platform linux/amd64,linux/arm64 --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) $1
+	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) || true
 endif
 ifeq ($(do_alpine),true)
 ifneq ("$(wildcard $1/alpine)","")
-	$(DOCKER) build --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine $1/alpine
-	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine
+	$(DOCKER) buildx build --platform linux/amd64,linux/arm64 --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine $1/alpine
+	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine || true
 endif
 endif
 endef

--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,12 @@ define build-version
 build-$1:
 ifeq ($(do_default),true)
 	$(DOCKER) buildx build --platform linux/amd64,linux/arm64 --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) $1
-	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1) || true
+	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)
 endif
 ifeq ($(do_alpine),true)
 ifneq ("$(wildcard $1/alpine)","")
 	$(DOCKER) buildx build --platform linux/amd64,linux/arm64 --pull -t $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine $1/alpine
-	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine || true
+	$(DOCKER) images          $(REPO_NAME)/$(IMAGE_NAME):$(shell echo $1)-alpine
 endif
 endif
 endef


### PR DESCRIPTION
action
- manual action trigger: workflow_dispatch
- remove ubuntu-24.04-arm runner
- remove redundant arm runner
- add REPO_NAME, so forked push succeeds

build
- use buildx to build multi platform images https://docs.docker.com/build/building/multi-platform/#multiple-native-nodes

built images: https://hub.docker.com/repository/docker/lodimup/postgis/tags

m4max is happy with the image
<img width="1168" alt="Screenshot 2025-03-17 at 0 17 33" src="https://github.com/user-attachments/assets/4827ab49-43c4-4a75-a790-c36428b3939a" />

note: there is a check whether to docker login or not, if docker is not logged in push stage will fail. Another branch removed the check to test if all build passes here: https://github.com/Lodimup/docker-postgis/actions/runs/13886065945/job/38850954488

todo:
- [ ] master variants are used for testing, build and test in respective platforms, when master variants are triggered don't use Buildx 