### PR TITLE
Remove unintended double space

### DIFF
--- a/update-postgis.sh
+++ b/update-postgis.sh
@@ -13,7 +13,7 @@ for DB in template_postgis "$POSTGRES_DB" "${@}"; do
     psql --dbname="$DB" -c "
         -- Upgrade PostGIS (includes raster)
         CREATE EXTENSION IF NOT EXISTS postgis VERSION '$POSTGIS_VERSION';
-        ALTER EXTENSION postgis  UPDATE TO '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis UPDATE TO '$POSTGIS_VERSION';
 
         -- Upgrade Topology
         CREATE EXTENSION IF NOT EXISTS postgis_topology VERSION '$POSTGIS_VERSION';


### PR DESCRIPTION
Removes a double space that was niggling me while reading the script.

It has no functional impact, but tidies things up for readability.