### PR TITLE
Multiarch images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,11 @@ defaults:
   run:
     shell: bash
 
-jobs:
+env:
+  DOCKERHUB_REPO: postgis/postgis
+  GITHUB_REPO: postgis/docker-postgis
 
+jobs:
   make-docker-images:
     strategy:
       matrix:
@@ -70,23 +73,127 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
-    - name: Build docker image for ${{ env.VERSION }} ${{ env.VARIANT }}
-      run: make test
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image for ${{ env.VERSION }} ${{ env.VARIANT }}
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: ${{ env.VERSION }}${{ env.VARIANT == 'alpine' && '/alpine' || ''}}
+        file: ${{ env.VERSION }}${{ env.VARIANT == 'alpine' && '/alpine' || ''}}/Dockerfile
+        load: true
+        push: false  # don't push until after testing
+
+    - name: Check out official-images repo
+      uses: actions/checkout@v5
+      with:
+        repository: docker-library/official-images
+        path: official-images
+        sparse-checkout: |
+          test
+
+    - name: Run official-images test script
+      run: |
+        ./official-images/test/run.sh -c ./official-images/test/config.sh -c test/postgis-config.sh ${{ steps.build.outputs.imageid }}
 
     - name: Login to dockerhub
+      id: login-dockerhub
       uses: docker/login-action@v3
-      if: ${{ (github.repository == 'postgis/docker-postgis') && (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') }}
+      if: ${{ (github.repository == env.GITHUB_REPO) && (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-    - name: Push docker image to dockerhub
-      # !!!! ONLY push the images when built on ubuntu-24.04 x86 runner for now, NOT for ubuntu-24.04-arm runners
-      if: ${{ (github.repository == 'postgis/docker-postgis') && (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && ( matrix.runner-platform == 'ubuntu-24.04' ) }}
-      env:
-        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-      run: make push
+    - name: Push image by digest
+      id: push
+      uses: docker/build-push-action@v5  # Build is cached, this is really just a push
+      if: ${{ (github.repository == env.GITHUB_REPO) && (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') }}
+      with:
+        context: ${{ env.VERSION }}${{ env.VARIANT == 'alpine' && '/alpine' || ''}}
+        file: ${{ env.VERSION }}${{ env.VARIANT == 'alpine' && '/alpine' || ''}}/Dockerfile
+        outputs: type=image,"name=${{ env.DOCKERHUB_REPO }}",push-by-digest=true,name-canonical=true,push=true
 
+    - name: Export digest
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.push.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+    - name: Upload digests
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-${{ env.VERSION }}-${{ env.VARIANT }}-${{ matrix.runner-platform }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  merge-manifests:
+    name: Merge manifests and push to DockerHub
+    needs: make-docker-images
+    runs-on: ubuntu-24.04-arm  # Always on arm, because why not
+    if: ${{ (github.repository == env.GITHUB_REPO) && (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') }}
+    env:
+      VERSION: ${{ matrix.postgres }}-${{ matrix.postgis }}
+      VARIANT: ${{ matrix.variant }}
+    strategy:
+      matrix:
+        # Copy from above, minus the runner-platform
+        postgres: [13, 14, 15, 16, 17]
+        postgis: ['3.5']
+        variant: [default, alpine]
+        include:
+          - postgres: 16
+            postgis: master
+            variant: default
+          - postgres: 17
+            postgis: master
+            variant: default
+          - postgres: 17
+            postgis: '3.6'
+            variant: alpine
+          - postgres: 18
+            postgis: '3.6'
+            variant: alpine
+          - postgres: 18
+            postgis: '3.6'
+            variant: default
+
+    steps:
+    - name: Login to dockerhub
+      id: login-dockerhub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: digests-${{ env.VERSION }}-${{ env.VARIANT }}-*
+        merge-multiple: true
+
+    - name: Docker Metadata
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.DOCKERHUB_REPO }}
+        tags: |
+          type=raw,value=${{ env.VERSION }}${{ env.VARIANT == 'alpine' && '-alpine' || ''}}
+
+    - name: Create manifest list and push
+      working-directory: ${{ runner.temp }}/digests
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)
+
+    - name: Inspect image  # Purely for debugging
+      run: |
+        sleep 5
+        docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ env.VERSION }}${{ env.VARIANT == 'alpine' && '-alpine' || ''}}


### PR DESCRIPTION
As discussed briefly in #216

The high-level logic here is to build each postgres/postgis/variant tuple natively (for speed) on both AMD64 and ARM64 separately, then push those images to Dockerhub by digest (ie, untagged). Do some magic with manifests/indexes to reference those digest and push them up to Dockerhub with the human-readable tags.

When someone pulls the image, dockerd will follow the index/manifest chain to resolve the correct image for the runtime's architecture.

If this is merged, it probably obviates #256, #405, #406 (nonexhaustive)