### PR TITLE
update debian trixie postgis  to  3.6.0+dfsg-2.pgdg13+1

### DIFF
--- a/16-master/Dockerfile
+++ b/16-master/Dockerfile
@@ -87,7 +87,7 @@ ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
 ENV CGAL_GIT_HASH=b3e2f204a41c1e508a6f018454b60b00aa3dc6fd
-ENV SFCGAL_GIT_HASH=cc408a34af9c3443a2cfb0f559b778a54a3702ab
+ENV SFCGAL_GIT_HASH=bac4309ca1c06ee4fc919d32c84dc463da7170e2
 RUN set -ex \
     && mkdir -p /usr/src \
     && cd /usr/src \
@@ -150,7 +150,7 @@ RUN set -ex \
     && rm -fr /usr/src/PROJ
 
 # geos
-ENV GEOS_GIT_HASH=16f53573f6bef38551801c2d449d4782775267bc
+ENV GEOS_GIT_HASH=2e12fa312d8ed12b36839ef20c193b49d695f1d4
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/libgeos/geos.git \
@@ -166,7 +166,7 @@ RUN set -ex \
     && rm -fr /usr/src/geos
 
 # gdal
-ENV GDAL_GIT_HASH=edcac5fc2ef9f42eb4a91cdc902820a58fb79d77
+ENV GDAL_GIT_HASH=b8d0f72f306e7fc0b5a511d96221277797301be5
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/gdal.git \
@@ -300,10 +300,10 @@ COPY --from=builder /usr/local /usr/local
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
 ENV CGAL_GIT_HASH=b3e2f204a41c1e508a6f018454b60b00aa3dc6fd
-ENV SFCGAL_GIT_HASH=cc408a34af9c3443a2cfb0f559b778a54a3702ab
+ENV SFCGAL_GIT_HASH=bac4309ca1c06ee4fc919d32c84dc463da7170e2
 ENV PROJ_GIT_HASH=6ef4961358a7525703c0f485b240582530f01b02
-ENV GEOS_GIT_HASH=16f53573f6bef38551801c2d449d4782775267bc
-ENV GDAL_GIT_HASH=edcac5fc2ef9f42eb4a91cdc902820a58fb79d77
+ENV GEOS_GIT_HASH=2e12fa312d8ed12b36839ef20c193b49d695f1d4
+ENV GDAL_GIT_HASH=b8d0f72f306e7fc0b5a511d96221277797301be5
 
 # Minimal command line test ( fail fast )
 RUN set -ex \
@@ -322,7 +322,7 @@ RUN set -ex \
             || echo "ogr2ogr missing PostgreSQL driver" && exit 1
 
 # install postgis
-ENV POSTGIS_GIT_HASH=9e3d207534699a2d43608b1f51c00780883126a1
+ENV POSTGIS_GIT_HASH=d1c28c62c4c5de585a11c6b07cd34e7576546d09
 
 RUN set -ex \
     && apt-get update \

--- a/17-master/Dockerfile
+++ b/17-master/Dockerfile
@@ -87,7 +87,7 @@ ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
 ENV CGAL_GIT_HASH=b3e2f204a41c1e508a6f018454b60b00aa3dc6fd
-ENV SFCGAL_GIT_HASH=cc408a34af9c3443a2cfb0f559b778a54a3702ab
+ENV SFCGAL_GIT_HASH=bac4309ca1c06ee4fc919d32c84dc463da7170e2
 RUN set -ex \
     && mkdir -p /usr/src \
     && cd /usr/src \
@@ -150,7 +150,7 @@ RUN set -ex \
     && rm -fr /usr/src/PROJ
 
 # geos
-ENV GEOS_GIT_HASH=16f53573f6bef38551801c2d449d4782775267bc
+ENV GEOS_GIT_HASH=2e12fa312d8ed12b36839ef20c193b49d695f1d4
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/libgeos/geos.git \
@@ -166,7 +166,7 @@ RUN set -ex \
     && rm -fr /usr/src/geos
 
 # gdal
-ENV GDAL_GIT_HASH=edcac5fc2ef9f42eb4a91cdc902820a58fb79d77
+ENV GDAL_GIT_HASH=b8d0f72f306e7fc0b5a511d96221277797301be5
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/gdal.git \
@@ -300,10 +300,10 @@ COPY --from=builder /usr/local /usr/local
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
 ENV CGAL_GIT_HASH=b3e2f204a41c1e508a6f018454b60b00aa3dc6fd
-ENV SFCGAL_GIT_HASH=cc408a34af9c3443a2cfb0f559b778a54a3702ab
+ENV SFCGAL_GIT_HASH=bac4309ca1c06ee4fc919d32c84dc463da7170e2
 ENV PROJ_GIT_HASH=6ef4961358a7525703c0f485b240582530f01b02
-ENV GEOS_GIT_HASH=16f53573f6bef38551801c2d449d4782775267bc
-ENV GDAL_GIT_HASH=edcac5fc2ef9f42eb4a91cdc902820a58fb79d77
+ENV GEOS_GIT_HASH=2e12fa312d8ed12b36839ef20c193b49d695f1d4
+ENV GDAL_GIT_HASH=b8d0f72f306e7fc0b5a511d96221277797301be5
 
 # Minimal command line test ( fail fast )
 RUN set -ex \
@@ -322,7 +322,7 @@ RUN set -ex \
             || echo "ogr2ogr missing PostgreSQL driver" && exit 1
 
 # install postgis
-ENV POSTGIS_GIT_HASH=9e3d207534699a2d43608b1f51c00780883126a1
+ENV POSTGIS_GIT_HASH=d1c28c62c4c5de585a11c6b07cd34e7576546d09
 
 RUN set -ex \
     && apt-get update \

--- a/18-3.6/Dockerfile
+++ b/18-3.6/Dockerfile
@@ -5,11 +5,11 @@
 FROM postgres:18-trixie
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.6.0+dfsg-1.pgdg13+1 spatial database extension with PostgreSQL 18 trixie" \
+      org.opencontainers.image.description="PostGIS 3.6.0+dfsg-2.pgdg13+1 spatial database extension with PostgreSQL 18 trixie" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR=3
-ENV POSTGIS_VERSION=3.6.0+dfsg-1.pgdg13+1
+ENV POSTGIS_VERSION=3.6.0+dfsg-2.pgdg13+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This image ensures that the default database created by the parent `postgres` im
 
 Unless `-e POSTGRES_DB` is passed to the container at startup time, this database will be named after the admin user (either `postgres` or the user specified with `-e POSTGRES_USER`). If you would prefer to use the older template database mechanism for enabling PostGIS, the image also provides a PostGIS-enabled template database called `template_postgis`.
 
-## Versions (2025-10-09)
+## Versions (2025-10-11)
 
 Supported architecture: `amd64` (x86-64)
 


### PR DESCRIPTION
The POSTGIS package (version 3.6.0+dfsg-2.pgdg13+1) has been updated on Debian Trixie. 

This is a quick fix applied via `./update.sh`.
