### PR TITLE
fix: pin dockerhub-description image to tag :4 due to issues with :latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ REPO_NAME  ?= postgis
 IMAGE_NAME ?= postgis
 
 DOCKER=docker
-DOCKERHUB_DESC_IMG=peterevans/dockerhub-description:latest
+DOCKERHUB_DESC_IMG=peterevans/dockerhub-description:4
 
 GIT=git
 OFFIMG_LOCAL_CLONE=$(HOME)/official-images


### PR DESCRIPTION
This PR pins the `peterevans/dockerhub-description` image ( https://github.com/peter-evans/dockerhub-description )  to tag `:4` instead of `:latest`,  
because the `latest` tag currently fails during the `make push-latest` GitHub Action step.

### Background:
The `latest` version of `peterevans/dockerhub-description` started throwing an error:
```
Digest: sha256:1a0868e3d3422a1fd4ec2c254e941bc7e0aeb9d945767cb9813018d603c3de47
Status: Downloaded newer image for peterevans/dockerhub-description:latest
Reading description source file
Acquiring token
Error: fetch is not defined
make: *** [Makefile:140: push-latest] Error 1
```

full error context : 
*  https://github.com/postgis/docker-postgis/actions/runs/18435594760/job/52538477329