### PR TITLE
Nproc build arg

### DIFF
--- a/13-3.5/alpine/Dockerfile
+++ b/13-3.5/alpine/Dockerfile
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE=postgres:13-alpine3.22
 FROM ${BASE_IMAGE}
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 13 Alpine" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -62,7 +65,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -78,7 +81,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/14-3.5/alpine/Dockerfile
+++ b/14-3.5/alpine/Dockerfile
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE=postgres:14-alpine3.22
 FROM ${BASE_IMAGE}
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 14 Alpine" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -62,7 +65,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -78,7 +81,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/15-3.5/alpine/Dockerfile
+++ b/15-3.5/alpine/Dockerfile
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE=postgres:15-alpine3.22
 FROM ${BASE_IMAGE}
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 15 Alpine" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -62,7 +65,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -78,7 +81,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/16-3.5/alpine/Dockerfile
+++ b/16-3.5/alpine/Dockerfile
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE=postgres:16-alpine3.22
 FROM ${BASE_IMAGE}
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 16 Alpine" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -62,7 +65,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -78,7 +81,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/16-master/Dockerfile
+++ b/16-master/Dockerfile
@@ -105,7 +105,7 @@ RUN set -ex \
 # cgal & sfcgal
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH=51b5eaa7c5ee0abc3b96a60ad9733f85ab06cc2c
+ENV CGAL_GIT_HASH=9b728c437c096113ba711a4186817ac90c97aae3
 ENV SFCGAL_GIT_HASH=0adcd006a4300a8de09c623b5d9c0e0d8bacfd1a
 RUN set -ex \
     && mkdir -p /usr/src \
@@ -185,7 +185,7 @@ RUN set -ex \
     && rm -fr /usr/src/geos
 
 # gdal
-ENV GDAL_GIT_HASH=16df635c529b940e26b04009385113a00d133a59
+ENV GDAL_GIT_HASH=0a76107e6e821bd098e4ff412958bf161c90153e
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/gdal.git \
@@ -304,6 +304,7 @@ RUN set -ex \
       libcfitsio9 \
       libfreexl1 \
       libfyba0 \
+      libgomp1 \
       libhdf5-103-1 \
       libkmlbase1 \
       libkmldom1 \
@@ -318,11 +319,11 @@ COPY --from=builder /usr/local /usr/local
 
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH=51b5eaa7c5ee0abc3b96a60ad9733f85ab06cc2c
+ENV CGAL_GIT_HASH=9b728c437c096113ba711a4186817ac90c97aae3
 ENV SFCGAL_GIT_HASH=0adcd006a4300a8de09c623b5d9c0e0d8bacfd1a
 ENV PROJ_GIT_HASH=b03fb3177baa2775bd476b3a1845f16ba61958fc
 ENV GEOS_GIT_HASH=c7ca3dd29bf379c43ae6f97fbc1bdfa10dcf630e
-ENV GDAL_GIT_HASH=16df635c529b940e26b04009385113a00d133a59
+ENV GDAL_GIT_HASH=0a76107e6e821bd098e4ff412958bf161c90153e
 
 # Minimal command line test ( fail fast )
 RUN set -ex \
@@ -341,7 +342,7 @@ RUN set -ex \
             || echo "ogr2ogr missing PostgreSQL driver" && exit 1
 
 # install postgis
-ENV POSTGIS_GIT_HASH=875ba8eb1c2782c80ae157e3490790d87470d447
+ENV POSTGIS_GIT_HASH=bf36aef0ca85b254b8576f0936d377612a4668c0
 
 RUN set -ex \
     && apt-get update \

--- a/16-master/Dockerfile
+++ b/16-master/Dockerfile
@@ -9,6 +9,9 @@ ARG DOCKER_CMAKE_BUILD_TYPE=Release
 ARG CGAL_GIT_BRANCH=main
 FROM docker.io/postgres:16-bullseye as builder
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS - master  spatial database extension with PostgreSQL 16 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -128,7 +131,7 @@ RUN set -ex \
        -DSFCGAL_BUILD_EXAMPLES=OFF \
        -DSFCGAL_BUILD_TESTS=OFF \
        -DSFCGAL_WITH_OSG=OFF \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     #
     ## testing with -DSFCGAL_BUILD_TESTS=ON
@@ -152,7 +155,7 @@ RUN set -ex \
         && echo "autotools version: 'autogen.sh' exists! Older version!"  \
         && ./autogen.sh \
         && ./configure --disable-static \
-        && make -j$(nproc) \
+        && make -j${NPROC:=$(nproc)} \
         && make install \
         ; \
     else \
@@ -161,7 +164,7 @@ RUN set -ex \
         && mkdir build \
         && cd build \
         && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-        && make -j$(nproc) \
+        && make -j${NPROC:=$(nproc)} \
         && make install \
         ; \
     fi \
@@ -179,7 +182,7 @@ RUN set -ex \
     && mkdir cmake-build \
     && cd cmake-build \
     && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/geos
@@ -249,7 +252,7 @@ RUN set -ex \
         ; \
     fi \
     \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/gdal
@@ -271,6 +274,7 @@ RUN set -ex \
 # -------------------------------------------
 FROM docker.io/postgres:16-bullseye
 
+ARG NPROC
 ARG DOCKER_CMAKE_BUILD_TYPE
 ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 
@@ -388,7 +392,7 @@ RUN set -ex \
 # https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
 # refresh proj data - workarounds: https://trac.osgeo.org/postgis/ticket/5316
     && projsync --system-directory --file ch_swisstopo_CHENyx06_ETRS \
@@ -402,7 +406,7 @@ RUN set -ex \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && ldconfig \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/17-3.5/alpine/Dockerfile
+++ b/17-3.5/alpine/Dockerfile
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE=postgres:17-alpine3.22
 FROM ${BASE_IMAGE}
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 17 Alpine" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -62,7 +65,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -78,7 +81,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/17-3.6/alpine/Dockerfile
+++ b/17-3.6/alpine/Dockerfile
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE=postgres:17-alpine3.22
 FROM ${BASE_IMAGE}
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.6.1 spatial database extension with PostgreSQL 17 Alpine" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -62,7 +65,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -78,7 +81,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/17-master/Dockerfile
+++ b/17-master/Dockerfile
@@ -105,7 +105,7 @@ RUN set -ex \
 # cgal & sfcgal
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH=51b5eaa7c5ee0abc3b96a60ad9733f85ab06cc2c
+ENV CGAL_GIT_HASH=9b728c437c096113ba711a4186817ac90c97aae3
 ENV SFCGAL_GIT_HASH=0adcd006a4300a8de09c623b5d9c0e0d8bacfd1a
 RUN set -ex \
     && mkdir -p /usr/src \
@@ -185,7 +185,7 @@ RUN set -ex \
     && rm -fr /usr/src/geos
 
 # gdal
-ENV GDAL_GIT_HASH=16df635c529b940e26b04009385113a00d133a59
+ENV GDAL_GIT_HASH=0a76107e6e821bd098e4ff412958bf161c90153e
 RUN set -ex \
     && cd /usr/src \
     && git clone https://github.com/OSGeo/gdal.git \
@@ -304,6 +304,7 @@ RUN set -ex \
       libcfitsio9 \
       libfreexl1 \
       libfyba0 \
+      libgomp1 \
       libhdf5-103-1 \
       libkmlbase1 \
       libkmldom1 \
@@ -318,11 +319,11 @@ COPY --from=builder /usr/local /usr/local
 
 ARG CGAL_GIT_BRANCH
 ENV CGAL_GIT_BRANCH=${CGAL_GIT_BRANCH}
-ENV CGAL_GIT_HASH=51b5eaa7c5ee0abc3b96a60ad9733f85ab06cc2c
+ENV CGAL_GIT_HASH=9b728c437c096113ba711a4186817ac90c97aae3
 ENV SFCGAL_GIT_HASH=0adcd006a4300a8de09c623b5d9c0e0d8bacfd1a
 ENV PROJ_GIT_HASH=b03fb3177baa2775bd476b3a1845f16ba61958fc
 ENV GEOS_GIT_HASH=c7ca3dd29bf379c43ae6f97fbc1bdfa10dcf630e
-ENV GDAL_GIT_HASH=16df635c529b940e26b04009385113a00d133a59
+ENV GDAL_GIT_HASH=0a76107e6e821bd098e4ff412958bf161c90153e
 
 # Minimal command line test ( fail fast )
 RUN set -ex \
@@ -341,7 +342,7 @@ RUN set -ex \
             || echo "ogr2ogr missing PostgreSQL driver" && exit 1
 
 # install postgis
-ENV POSTGIS_GIT_HASH=875ba8eb1c2782c80ae157e3490790d87470d447
+ENV POSTGIS_GIT_HASH=bf36aef0ca85b254b8576f0936d377612a4668c0
 
 RUN set -ex \
     && apt-get update \

--- a/17-master/Dockerfile
+++ b/17-master/Dockerfile
@@ -9,6 +9,9 @@ ARG DOCKER_CMAKE_BUILD_TYPE=Release
 ARG CGAL_GIT_BRANCH=main
 FROM docker.io/postgres:17-bullseye as builder
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS - master  spatial database extension with PostgreSQL 17 bullseye" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -128,7 +131,7 @@ RUN set -ex \
        -DSFCGAL_BUILD_EXAMPLES=OFF \
        -DSFCGAL_BUILD_TESTS=OFF \
        -DSFCGAL_WITH_OSG=OFF \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     #
     ## testing with -DSFCGAL_BUILD_TESTS=ON
@@ -152,7 +155,7 @@ RUN set -ex \
         && echo "autotools version: 'autogen.sh' exists! Older version!"  \
         && ./autogen.sh \
         && ./configure --disable-static \
-        && make -j$(nproc) \
+        && make -j${NPROC:=$(nproc)} \
         && make install \
         ; \
     else \
@@ -161,7 +164,7 @@ RUN set -ex \
         && mkdir build \
         && cd build \
         && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-        && make -j$(nproc) \
+        && make -j${NPROC:=$(nproc)} \
         && make install \
         ; \
     fi \
@@ -179,7 +182,7 @@ RUN set -ex \
     && mkdir cmake-build \
     && cd cmake-build \
     && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/geos
@@ -249,7 +252,7 @@ RUN set -ex \
         ; \
     fi \
     \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/gdal
@@ -271,6 +274,7 @@ RUN set -ex \
 # -------------------------------------------
 FROM docker.io/postgres:17-bullseye
 
+ARG NPROC
 ARG DOCKER_CMAKE_BUILD_TYPE
 ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 
@@ -388,7 +392,7 @@ RUN set -ex \
 # https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
 # refresh proj data - workarounds: https://trac.osgeo.org/postgis/ticket/5316
     && projsync --system-directory --file ch_swisstopo_CHENyx06_ETRS \
@@ -402,7 +406,7 @@ RUN set -ex \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && ldconfig \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/18-3.6/alpine/Dockerfile
+++ b/18-3.6/alpine/Dockerfile
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE=postgres:18-alpine3.22
 FROM ${BASE_IMAGE}
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.6.1 spatial database extension with PostgreSQL 18 Alpine" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -62,7 +65,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -78,7 +81,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE=postgres:%%PG_MAJOR%%-alpine3.22
 FROM ${BASE_IMAGE}
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS %%POSTGIS_VERSION%% spatial database extension with PostgreSQL %%PG_MAJOR%% Alpine" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -62,7 +65,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -78,7 +81,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -304,6 +304,7 @@ RUN set -ex \
       libcfitsio9 \
       libfreexl1 \
       libfyba0 \
+      libgomp1 \
       libhdf5-103-1 \
       libkmlbase1 \
       libkmldom1 \

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -9,6 +9,9 @@ ARG DOCKER_CMAKE_BUILD_TYPE=Release
 ARG CGAL_GIT_BRANCH=main
 FROM docker.io/postgres:%%PG_MAJOR%%-%%DEBIAN_VERSION%% as builder
 
+ARG NPROC
+ENV NPROC=${NPROC}
+
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS - master  spatial database extension with PostgreSQL %%PG_MAJOR%% %%DEBIAN_VERSION%%" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
@@ -128,7 +131,7 @@ RUN set -ex \
        -DSFCGAL_BUILD_EXAMPLES=OFF \
        -DSFCGAL_BUILD_TESTS=OFF \
        -DSFCGAL_WITH_OSG=OFF \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     #
     ## testing with -DSFCGAL_BUILD_TESTS=ON
@@ -152,7 +155,7 @@ RUN set -ex \
         && echo "autotools version: 'autogen.sh' exists! Older version!"  \
         && ./autogen.sh \
         && ./configure --disable-static \
-        && make -j$(nproc) \
+        && make -j${NPROC:=$(nproc)} \
         && make install \
         ; \
     else \
@@ -161,7 +164,7 @@ RUN set -ex \
         && mkdir build \
         && cd build \
         && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-        && make -j$(nproc) \
+        && make -j${NPROC:=$(nproc)} \
         && make install \
         ; \
     fi \
@@ -179,7 +182,7 @@ RUN set -ex \
     && mkdir cmake-build \
     && cd cmake-build \
     && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/geos
@@ -249,7 +252,7 @@ RUN set -ex \
         ; \
     fi \
     \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/gdal
@@ -271,6 +274,7 @@ RUN set -ex \
 # -------------------------------------------
 FROM docker.io/postgres:%%PG_MAJOR%%-%%DEBIAN_VERSION%%
 
+ARG NPROC
 ARG DOCKER_CMAKE_BUILD_TYPE
 ENV DOCKER_CMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE}
 
@@ -388,7 +392,7 @@ RUN set -ex \
 # https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
     && ./configure \
         --enable-lto \
-    && make -j$(nproc) \
+    && make -j${NPROC:=$(nproc)} \
     && make install \
 # refresh proj data - workarounds: https://trac.osgeo.org/postgis/ticket/5316
     && projsync --system-directory --file ch_swisstopo_CHENyx06_ETRS \
@@ -402,7 +406,7 @@ RUN set -ex \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && ldconfig \
     && cd regress \
-    && make -j$(nproc) check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This image ensures that the default database created by the parent `postgres` im
 
 Unless `-e POSTGRES_DB` is passed to the container at startup time, this database will be named after the admin user (either `postgres` or the user specified with `-e POSTGRES_USER`). If you would prefer to use the older template database mechanism for enabling PostGIS, the image also provides a PostGIS-enabled template database called `template_postgis`.
 
-## Versions (2026-02-03)
+## Versions (2026-02-04)
 
 Supported architecture: `amd64` (x86-64)
 


### PR DESCRIPTION
Helps keeping control of your machine while building. Example:

`podman build --build-args NPROC=$(nproc --ignore 4) .`