### PR TITLE
fix: update ``NPROC`` to be only a build argument

### DIFF
--- a/13-3.5/alpine/Dockerfile
+++ b/13-3.5/alpine/Dockerfile
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=postgres:13-alpine3.22
 FROM ${BASE_IMAGE}
 
-ARG NPROC
-ENV NPROC=${NPROC}
+ARG NPROC=
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 13 Alpine" \
@@ -65,7 +64,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -81,7 +80,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/14-3.5/alpine/Dockerfile
+++ b/14-3.5/alpine/Dockerfile
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=postgres:14-alpine3.22
 FROM ${BASE_IMAGE}
 
-ARG NPROC
-ENV NPROC=${NPROC}
+ARG NPROC=
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 14 Alpine" \
@@ -65,7 +64,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -81,7 +80,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/15-3.5/alpine/Dockerfile
+++ b/15-3.5/alpine/Dockerfile
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=postgres:15-alpine3.22
 FROM ${BASE_IMAGE}
 
-ARG NPROC
-ENV NPROC=${NPROC}
+ARG NPROC=
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 15 Alpine" \
@@ -65,7 +64,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -81,7 +80,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/16-3.5/alpine/Dockerfile
+++ b/16-3.5/alpine/Dockerfile
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=postgres:16-alpine3.22
 FROM ${BASE_IMAGE}
 
-ARG NPROC
-ENV NPROC=${NPROC}
+ARG NPROC=
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 16 Alpine" \
@@ -65,7 +64,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -81,7 +80,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/16-master/Dockerfile
+++ b/16-master/Dockerfile
@@ -7,10 +7,10 @@
 
 ARG DOCKER_CMAKE_BUILD_TYPE=Release
 ARG CGAL_GIT_BRANCH=main
+ARG NPROC=
 FROM docker.io/postgres:16-bullseye as builder
 
 ARG NPROC
-ENV NPROC=${NPROC}
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS - master  spatial database extension with PostgreSQL 16 bullseye" \
@@ -131,7 +131,7 @@ RUN set -ex \
        -DSFCGAL_BUILD_EXAMPLES=OFF \
        -DSFCGAL_BUILD_TESTS=OFF \
        -DSFCGAL_WITH_OSG=OFF \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     #
     ## testing with -DSFCGAL_BUILD_TESTS=ON
@@ -155,7 +155,7 @@ RUN set -ex \
         && echo "autotools version: 'autogen.sh' exists! Older version!"  \
         && ./autogen.sh \
         && ./configure --disable-static \
-        && make -j${NPROC:=$(nproc)} \
+        && make -j${NPROC:-$(nproc)} \
         && make install \
         ; \
     else \
@@ -164,7 +164,7 @@ RUN set -ex \
         && mkdir build \
         && cd build \
         && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-        && make -j${NPROC:=$(nproc)} \
+        && make -j${NPROC:-$(nproc)} \
         && make install \
         ; \
     fi \
@@ -182,7 +182,7 @@ RUN set -ex \
     && mkdir cmake-build \
     && cd cmake-build \
     && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/geos
@@ -252,7 +252,7 @@ RUN set -ex \
         ; \
     fi \
     \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/gdal
@@ -392,7 +392,7 @@ RUN set -ex \
 # https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
 # refresh proj data - workarounds: https://trac.osgeo.org/postgis/ticket/5316
     && projsync --system-directory --file ch_swisstopo_CHENyx06_ETRS \
@@ -406,7 +406,7 @@ RUN set -ex \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && ldconfig \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/17-3.5/alpine/Dockerfile
+++ b/17-3.5/alpine/Dockerfile
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=postgres:17-alpine3.22
 FROM ${BASE_IMAGE}
 
-ARG NPROC
-ENV NPROC=${NPROC}
+ARG NPROC=
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.5.4 spatial database extension with PostgreSQL 17 Alpine" \
@@ -65,7 +64,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -81,7 +80,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/17-3.6/alpine/Dockerfile
+++ b/17-3.6/alpine/Dockerfile
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=postgres:17-alpine3.22
 FROM ${BASE_IMAGE}
 
-ARG NPROC
-ENV NPROC=${NPROC}
+ARG NPROC=
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.6.1 spatial database extension with PostgreSQL 17 Alpine" \
@@ -65,7 +64,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -81,7 +80,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/17-master/Dockerfile
+++ b/17-master/Dockerfile
@@ -7,10 +7,10 @@
 
 ARG DOCKER_CMAKE_BUILD_TYPE=Release
 ARG CGAL_GIT_BRANCH=main
+ARG NPROC=
 FROM docker.io/postgres:17-bullseye as builder
 
 ARG NPROC
-ENV NPROC=${NPROC}
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS - master  spatial database extension with PostgreSQL 17 bullseye" \
@@ -131,7 +131,7 @@ RUN set -ex \
        -DSFCGAL_BUILD_EXAMPLES=OFF \
        -DSFCGAL_BUILD_TESTS=OFF \
        -DSFCGAL_WITH_OSG=OFF \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     #
     ## testing with -DSFCGAL_BUILD_TESTS=ON
@@ -155,7 +155,7 @@ RUN set -ex \
         && echo "autotools version: 'autogen.sh' exists! Older version!"  \
         && ./autogen.sh \
         && ./configure --disable-static \
-        && make -j${NPROC:=$(nproc)} \
+        && make -j${NPROC:-$(nproc)} \
         && make install \
         ; \
     else \
@@ -164,7 +164,7 @@ RUN set -ex \
         && mkdir build \
         && cd build \
         && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-        && make -j${NPROC:=$(nproc)} \
+        && make -j${NPROC:-$(nproc)} \
         && make install \
         ; \
     fi \
@@ -182,7 +182,7 @@ RUN set -ex \
     && mkdir cmake-build \
     && cd cmake-build \
     && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/geos
@@ -252,7 +252,7 @@ RUN set -ex \
         ; \
     fi \
     \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/gdal
@@ -392,7 +392,7 @@ RUN set -ex \
 # https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
 # refresh proj data - workarounds: https://trac.osgeo.org/postgis/ticket/5316
     && projsync --system-directory --file ch_swisstopo_CHENyx06_ETRS \
@@ -406,7 +406,7 @@ RUN set -ex \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && ldconfig \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/18-3.6/alpine/Dockerfile
+++ b/18-3.6/alpine/Dockerfile
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=postgres:18-alpine3.22
 FROM ${BASE_IMAGE}
 
-ARG NPROC
-ENV NPROC=${NPROC}
+ARG NPROC=
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS 3.6.1 spatial database extension with PostgreSQL 18 Alpine" \
@@ -65,7 +64,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -81,7 +80,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=postgres:%%PG_MAJOR%%-alpine3.22
 FROM ${BASE_IMAGE}
 
-ARG NPROC
-ENV NPROC=${NPROC}
+ARG NPROC=
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS %%POSTGIS_VERSION%% spatial database extension with PostgreSQL %%PG_MAJOR%% Alpine" \
@@ -65,7 +64,7 @@ RUN set -eux \
     && ./autogen.sh \
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     \
 # This section is for refreshing the proj data for the regression tests.
@@ -81,7 +80,7 @@ RUN set -eux \
     && su postgres -c 'pg_ctl -D /tempdb init' \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -7,10 +7,10 @@
 
 ARG DOCKER_CMAKE_BUILD_TYPE=Release
 ARG CGAL_GIT_BRANCH=main
+ARG NPROC=
 FROM docker.io/postgres:%%PG_MAJOR%%-%%DEBIAN_VERSION%% as builder
 
 ARG NPROC
-ENV NPROC=${NPROC}
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
       org.opencontainers.image.description="PostGIS - master  spatial database extension with PostgreSQL %%PG_MAJOR%% %%DEBIAN_VERSION%%" \
@@ -131,7 +131,7 @@ RUN set -ex \
        -DSFCGAL_BUILD_EXAMPLES=OFF \
        -DSFCGAL_BUILD_TESTS=OFF \
        -DSFCGAL_WITH_OSG=OFF \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     #
     ## testing with -DSFCGAL_BUILD_TESTS=ON
@@ -155,7 +155,7 @@ RUN set -ex \
         && echo "autotools version: 'autogen.sh' exists! Older version!"  \
         && ./autogen.sh \
         && ./configure --disable-static \
-        && make -j${NPROC:=$(nproc)} \
+        && make -j${NPROC:-$(nproc)} \
         && make install \
         ; \
     else \
@@ -164,7 +164,7 @@ RUN set -ex \
         && mkdir build \
         && cd build \
         && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-        && make -j${NPROC:=$(nproc)} \
+        && make -j${NPROC:-$(nproc)} \
         && make install \
         ; \
     fi \
@@ -182,7 +182,7 @@ RUN set -ex \
     && mkdir cmake-build \
     && cd cmake-build \
     && cmake .. -DCMAKE_BUILD_TYPE=${DOCKER_CMAKE_BUILD_TYPE} -DBUILD_TESTING=OFF \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/geos
@@ -252,7 +252,7 @@ RUN set -ex \
         ; \
     fi \
     \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
     && cd / \
     && rm -fr /usr/src/gdal
@@ -392,7 +392,7 @@ RUN set -ex \
 # https://anonscm.debian.org/cgit/pkg-grass/postgis.git/tree/debian/rules?h=jessie
     && ./configure \
         --enable-lto \
-    && make -j${NPROC:=$(nproc)} \
+    && make -j${NPROC:-$(nproc)} \
     && make install \
 # refresh proj data - workarounds: https://trac.osgeo.org/postgis/ticket/5316
     && projsync --system-directory --file ch_swisstopo_CHENyx06_ETRS \
@@ -406,7 +406,7 @@ RUN set -ex \
     && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
     && ldconfig \
     && cd regress \
-    && make -j${NPROC:=$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
+    && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis;"' \
     && su postgres -c 'psql    -c "CREATE EXTENSION IF NOT EXISTS postgis_raster;"' \


### PR DESCRIPTION
This change fixes the ``NPROC`` build argument persisting in the container's runtime environment.