### PR TITLE
Fix Alpine/master regression tests for ARM64 builds

### DIFF
--- a/13-3.5/alpine/Dockerfile
+++ b/13-3.5/alpine/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \

--- a/14-3.5/alpine/Dockerfile
+++ b/14-3.5/alpine/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \

--- a/15-3.5/alpine/Dockerfile
+++ b/15-3.5/alpine/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \

--- a/16-3.5/alpine/Dockerfile
+++ b/16-3.5/alpine/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \

--- a/16-master/Dockerfile
+++ b/16-master/Dockerfile
@@ -403,7 +403,7 @@ RUN set -ex \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && ldconfig \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \

--- a/17-3.5/alpine/Dockerfile
+++ b/17-3.5/alpine/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \

--- a/17-3.6/alpine/Dockerfile
+++ b/17-3.6/alpine/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \

--- a/17-master/Dockerfile
+++ b/17-master/Dockerfile
@@ -403,7 +403,7 @@ RUN set -ex \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && ldconfig \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \

--- a/18-3.6/alpine/Dockerfile
+++ b/18-3.6/alpine/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -78,7 +78,7 @@ RUN set -eux \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \
     \

--- a/Dockerfile.master.template
+++ b/Dockerfile.master.template
@@ -403,7 +403,7 @@ RUN set -ex \
     && mkdir /tempdb \
     && chown -R postgres:postgres /tempdb \
     && su postgres -c 'pg_ctl -D /tempdb init' \
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start ' \
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start ' \
     && ldconfig \
     && cd regress \
     && make -j${NPROC:-$(nproc)} check RUNTESTFLAGS="--extension --verbose" PGUSER=postgres \


### PR DESCRIPTION
This fixes the Alpine and master Dockerfile regression test failures on ARM64 that @ImreSamu identified in #393.

## The problem

PostgreSQL's JIT compilation causes "stuck spinlock" crashes when the regression tests run under QEMU emulation for ARM64. The CI matrix already builds on native `ubuntu-24.04-arm` runners, but the Alpine and master variants fail during the regression test phase.

## The fix

Disable JIT during the regression test database startup by passing `--jit=off` to `pg_ctl`:

```diff
-    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o '-F' start '
+    && su postgres -c 'pg_ctl -D /tempdb -c -l /tmp/logfile -o "-F --jit=off" start '
```

This only affects the build-time regression tests — JIT remains enabled in the final running image.

Applied to both templates and all generated Dockerfiles (11 files, same single-line change).

## Testing

- All stable builds pass on both amd64 and arm64 runners (26/26)
- PostGIS spatial queries verified on native Apple Silicon Mac

Fixes #393
Refs #216, #387